### PR TITLE
Updating SDK to plumb latest APIs / updates in api spec

### DIFF
--- a/generated/Chat.ts
+++ b/generated/Chat.ts
@@ -78,7 +78,6 @@ type ChatCompletionRequest = {
       }>
     | undefined;
   force_search?: boolean | undefined;
-  result_format?: ("text" | "markdown" | "json") | undefined;
   include_citations?: boolean | undefined;
   temperature?: number | undefined;
   top_p?: number | undefined;
@@ -130,10 +129,6 @@ const ChatCompletionRequest: z.ZodType<ChatCompletionRequest> = z
       .passthrough()
       .optional(),
     force_search: z.boolean().optional().default(false),
-    result_format: z
-      .enum(["text", "markdown", "json"])
-      .optional()
-      .default("text"),
     include_citations: z.boolean().optional().default(true),
     temperature: z.number().gte(0).lte(2).optional().default(0.7),
     top_p: z.number().gte(0).lte(1).optional().default(1),

--- a/generated/Collections.ts
+++ b/generated/Collections.ts
@@ -204,40 +204,46 @@ const RichTranscript = z
     file_id: z.string(),
     content: z.string().optional(),
     title: z.string(),
-    summary: z.string(),
-    speech: z.array(
-      z
-        .object({
-          text: z.string(),
-          start_time: z.number(),
-          end_time: z.number(),
-        })
-        .partial()
-        .strict()
-        .passthrough()
-    ),
-    visual_scene_description: z.array(
-      z
-        .object({
-          text: z.string(),
-          start_time: z.number(),
-          end_time: z.number(),
-        })
-        .partial()
-        .strict()
-        .passthrough()
-    ),
-    scene_text: z.array(
-      z
-        .object({
-          text: z.string(),
-          start_time: z.number(),
-          end_time: z.number(),
-        })
-        .partial()
-        .strict()
-        .passthrough()
-    ),
+    summary: z.string().optional(),
+    speech: z
+      .array(
+        z
+          .object({
+            text: z.string(),
+            start_time: z.number(),
+            end_time: z.number(),
+          })
+          .partial()
+          .strict()
+          .passthrough()
+      )
+      .optional(),
+    visual_scene_description: z
+      .array(
+        z
+          .object({
+            text: z.string(),
+            start_time: z.number(),
+            end_time: z.number(),
+          })
+          .partial()
+          .strict()
+          .passthrough()
+      )
+      .optional(),
+    scene_text: z
+      .array(
+        z
+          .object({
+            text: z.string(),
+            start_time: z.number(),
+            end_time: z.number(),
+          })
+          .partial()
+          .strict()
+          .passthrough()
+      )
+      .optional(),
   })
   .strict()
   .passthrough();

--- a/generated/Collections.ts
+++ b/generated/Collections.ts
@@ -8,10 +8,19 @@ type Collection = {
   object: "collection";
   name: string;
   description?: (string | null) | undefined;
+  collection_type: "entities" | "rich-transcripts";
   extract_config?:
     | Partial<{
         prompt: string;
         schema: {};
+      }>
+    | undefined;
+  transcribe_config?:
+    | Partial<{
+        enable_summary: boolean;
+        enable_speech: boolean;
+        enable_scene_text: boolean;
+        enable_visual_scene_description: boolean;
       }>
     | undefined;
   created_at: number;
@@ -52,10 +61,22 @@ const Collection: z.ZodType<Collection> = z
     object: z.literal("collection"),
     name: z.string(),
     description: z.union([z.string(), z.null()]).optional(),
+    collection_type: z.enum(["entities", "rich-transcripts"]),
     extract_config: z
       .object({
         prompt: z.string(),
         schema: z.object({}).partial().strict().passthrough(),
+      })
+      .partial()
+      .strict()
+      .passthrough()
+      .optional(),
+    transcribe_config: z
+      .object({
+        enable_summary: z.boolean().default(true),
+        enable_speech: z.boolean().default(true),
+        enable_scene_text: z.boolean().default(false),
+        enable_visual_scene_description: z.boolean().default(false),
       })
       .partial()
       .strict()
@@ -111,12 +132,24 @@ const CollectionFileList: z.ZodType<CollectionFileList> = z
   .passthrough();
 const NewCollection = z
   .object({
+    collection_type: z.enum(["entities", "rich-transcripts"]),
     name: z.string(),
     description: z.union([z.string(), z.null()]).optional(),
     extract_config: z
       .object({
         prompt: z.string(),
         schema: z.object({}).partial().strict().passthrough(),
+      })
+      .partial()
+      .strict()
+      .passthrough()
+      .optional(),
+    transcribe_config: z
+      .object({
+        enable_summary: z.boolean().default(true),
+        enable_speech: z.boolean().default(true),
+        enable_scene_text: z.boolean().default(false),
+        enable_visual_scene_description: z.boolean().default(false),
       })
       .partial()
       .strict()
@@ -165,66 +198,46 @@ const FileEntities = z
   })
   .strict()
   .passthrough();
-
-// TODO: Remove this once we have a new endpoint for this setup
-const FileDescription = z
+const RichTranscript = z
   .object({
     collection_id: z.string(),
     file_id: z.string(),
-    title: z.string().optional(),
-    summary: z.string().optional(),
-    segment_docs: z
-      .array(
-        z
-          .object({
-            segment_id: z.union([z.string(), z.number()]),
-            start_time: z.number(),
-            end_time: z.number(),
-            title: z.string(),
-            summary: z.string(),
-            visual_description: z.array(
-              z
-                .object({
-                  text: z.string(),
-                  start_time: z.number(),
-                  end_time: z.number(),
-                })
-                .partial()
-                .strict()
-                .passthrough()
-            ),
-            scene_text: z.array(
-              z
-                .object({
-                  text: z.string(),
-                  start_time: z.number(),
-                  end_time: z.number(),
-                })
-                .partial()
-                .strict()
-                .passthrough()
-            ),
-            speech: z.array(
-              z
-                .object({
-                  speaker: z.string(),
-                  text: z.string(),
-                  start_time: z.number(),
-                  end_time: z.number(),
-                })
-                .partial()
-                .strict()
-                .passthrough()
-            ),
-          })
-          .partial()
-          .strict()
-          .passthrough()
-      )
-      .optional(),
-    total: z.number().int().optional(),
-    limit: z.number().int().optional(),
-    offset: z.number().int().optional(),
+    content: z.string().optional(),
+    title: z.string(),
+    summary: z.string(),
+    speech: z.array(
+      z
+        .object({
+          text: z.string(),
+          start_time: z.number(),
+          end_time: z.number(),
+        })
+        .partial()
+        .strict()
+        .passthrough()
+    ),
+    visual_scene_description: z.array(
+      z
+        .object({
+          text: z.string(),
+          start_time: z.number(),
+          end_time: z.number(),
+        })
+        .partial()
+        .strict()
+        .passthrough()
+    ),
+    scene_text: z.array(
+      z
+        .object({
+          text: z.string(),
+          start_time: z.number(),
+          end_time: z.number(),
+        })
+        .partial()
+        .strict()
+        .passthrough()
+    ),
   })
   .strict()
   .passthrough();
@@ -245,8 +258,7 @@ export const schemas = {
   CollectionDelete,
   CollectionFileDelete,
   FileEntities,
-  // TODO: Remove this once we have a new endpoint for this setup
-  FileDescription,
+  RichTranscript,
   AddYouTubeCollectionFile,
 };
 
@@ -255,7 +267,7 @@ const endpoints = makeApi([
     method: "post",
     path: "/collections",
     alias: "createCollection",
-    description: `Create a new collection to organize and process video files`,
+    description: `Create a new collection to organize and process video files. Collections are used to group files together and process them in a consistent way.`,
     requestFormat: "json",
     parameters: [
       {
@@ -315,6 +327,11 @@ const endpoints = makeApi([
         name: "sort",
         type: "Query",
         schema: z.enum(["asc", "desc"]).optional().default("desc"),
+      },
+      {
+        name: "collection_type",
+        type: "Query",
+        schema: z.enum(["entities", "rich-transcripts"]).optional(),
       },
     ],
     response: CollectionList,
@@ -556,7 +573,7 @@ const endpoints = makeApi([
     method: "get",
     path: "/collections/:collection_id/videos/:file_id/entities",
     alias: "getEntities",
-    description: `Retrieve all extracted entities for a specific file in a collection`,
+    description: `Retrieve all extracted entities for a specific file in a collection. This API is only available when the a collection is created with collection_type &#x27;entities&#x27;`,
     requestFormat: "json",
     parameters: [
       {
@@ -583,6 +600,11 @@ const endpoints = makeApi([
     response: FileEntities,
     errors: [
       {
+        status: 400,
+        description: `Collection type is not &#x27;entities&#x27;`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
         status: 404,
         description: `Collection or file not found`,
         schema: z.object({ error: z.string() }).strict().passthrough(),
@@ -595,11 +617,10 @@ const endpoints = makeApi([
     ],
   },
   {
-    // TODO: Remove this once we have a new endpoint for this setup
     method: "get",
-    path: "/collections/:collection_id/videos/:file_id/description",
-    alias: "getDescription",
-    description: `Retrieve the processed video summary description and segment documents for a file in a collection`,
+    path: "/collections/:collection_id/videos/:file_id/rich-transcripts",
+    alias: "getTranscripts",
+    description: `Retrieve rich transcription data for a specific file in a collection. This API is only available when the a collection is created with collection_type &#x27;rich-transcripts&#x27;`,
     requestFormat: "json",
     parameters: [
       {
@@ -613,18 +634,18 @@ const endpoints = makeApi([
         schema: z.string(),
       },
       {
-        name: "limit",
+        name: "response_format",
         type: "Query",
-        schema: z.number().int().lte(100).optional().default(50),
-      },
-      {
-        name: "offset",
-        type: "Query",
-        schema: z.number().int().optional().default(0),
+        schema: z.enum(["json", "markdown"]).optional().default("json"),
       },
     ],
-    response: FileDescription,
+    response: RichTranscript,
     errors: [
+      {
+        status: 400,
+        description: `Collection type is not &#x27;rich-transcripts&#x27;`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
       {
         status: 404,
         description: `Collection or file not found`,
@@ -636,7 +657,7 @@ const endpoints = makeApi([
         schema: z.object({ error: z.string() }).strict().passthrough(),
       },
     ],
-  },    
+  },
   {
     method: "post",
     path: "/collections/:collection_id/youtube",

--- a/generated/Collections.ts
+++ b/generated/Collections.ts
@@ -203,7 +203,7 @@ const RichTranscript = z
     collection_id: z.string(),
     file_id: z.string(),
     content: z.string().optional(),
-    title: z.string(),
+    title: z.string().optional(),
     summary: z.string().optional(),
     speech: z
       .array(

--- a/generated/Extract.ts
+++ b/generated/Extract.ts
@@ -184,6 +184,11 @@ const endpoints = makeApi([
         type: "Query",
         schema: z.string().optional(),
       },
+      {
+        name: "url",
+        type: "Query",
+        schema: z.string().optional(),
+      },
     ],
     response: ExtractList,
     errors: [

--- a/generated/Transcribe.ts
+++ b/generated/Transcribe.ts
@@ -227,6 +227,11 @@ const endpoints = makeApi([
         schema: z.string().optional(),
       },
       {
+        name: "url",
+        type: "Query",
+        schema: z.string().optional(),
+      },
+      {
         name: "response_format",
         type: "Query",
         schema: z.enum(["json", "markdown"]).optional().default("json"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviaryhq/cloudglue-js",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviaryhq/cloudglue-js",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "Elastic-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviaryhq/cloudglue-js",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "CloudGlue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -43,14 +43,22 @@ interface ListCollectionParams {
   offset?: number;
   order?: 'name' | 'created_at';
   sort?: 'asc' | 'desc';
+  collection_type?: 'entities' | 'rich-transcripts';
 }
 
 interface CreateCollectionParams {
+  collection_type: 'entities' | 'rich-transcripts';
   name: string;
   description?: string;
   extract_config?: {
     prompt?: string;
     schema?: Record<string, any>;
+  };
+  transcribe_config?: {
+    enable_summary?: boolean;
+    enable_speech?: boolean;
+    enable_scene_text?: boolean;
+    enable_visual_scene_description?: boolean;
   };
 }
 
@@ -81,7 +89,6 @@ interface ChatCompletionParams {
     }>;
   };
   force_search?: boolean;
-  result_format?: 'text' | 'markdown' | 'json';
   include_citations?: boolean;
   temperature?: number;
   top_p?: number;
@@ -183,9 +190,8 @@ class EnhancedCollectionsApi {
     } as any);
   }
 
-  // TODO: Remove this once we have a new endpoint for this setup
-  async getDescription(collectionId: string, fileId: string, limit?: number, offset?: number) {
-    return this.api.getDescription({
+  async getTranscripts(collectionId: string, fileId: string, limit?: number, offset?: number) {
+    return this.api.getTranscripts({
       params: { collection_id: collectionId, file_id: fileId },
       queries: { limit, offset }
     } as any);
@@ -237,6 +243,7 @@ class EnhancedTranscribeApi {
     status?: 'pending' | 'processing' | 'completed' | 'failed' | 'not_applicable';
     created_before?: string;
     created_after?: string;
+    url?: string;
     response_format?: 'json' | 'markdown';
   } = {}) {
     return this.api.listTranscribes({ queries: params } as any);
@@ -266,6 +273,7 @@ class EnhancedExtractApi {
     status?: 'pending' | 'processing' | 'completed' | 'failed' | 'not_applicable';
     created_before?: string;
     created_after?: string;
+    url?: string;
   } = {}) {
     return this.api.listExtracts({ queries: params } as any);
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -190,10 +190,10 @@ class EnhancedCollectionsApi {
     } as any);
   }
 
-  async getTranscripts(collectionId: string, fileId: string, limit?: number, offset?: number) {
+  async getTranscripts(collectionId: string, fileId: string, limit?: number, offset?: number, response_format?: 'markdown' | 'json') {
     return this.api.getTranscripts({
       params: { collection_id: collectionId, file_id: fileId },
-      queries: { limit, offset }
+      queries: { limit, offset, response_format }
     } as any);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,9 +25,6 @@ export type {
   CollectionFileList,
   ChatMessage,
   ChatCompletionResponse,
-  // TODO: Remove these two once we have a new endpoint for this setup
-  DescriptionSegment,
-  CollectionVideoDescription,
   Transcribe,
   TranscribeList,
   Extract,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,4 +32,5 @@ export type {
   EntitySegment,
   CollectionVideoEntities,
   NewCollectionParams,
+  RichTranscript,
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,18 +35,6 @@ export type CollectionFile = z.infer<typeof collectionsSchemas.CollectionFile>;
  */
 export type CollectionFileList = z.infer<typeof collectionsSchemas.CollectionFileList>;
 
-/**
- * TODO: Remove this once we have a new endpoint for this setup
- * Represents a segment of video description containing speech, text, and visual information
- * This is inferred from the FileDescription schema's segment_docs array type
- */
-export type DescriptionSegment = NonNullable<z.infer<typeof collectionsSchemas.FileDescription>['segment_docs']>[number];
-
-/**
- * TODO: Remove this once we have a new endpoint for this setup
- * Represents the full description response for a video in a collection
- */
-export type CollectionVideoDescription = z.infer<typeof collectionsSchemas.FileDescription>;
 
 /**
  * Represents a segment of video with extracted entities
@@ -96,3 +84,10 @@ export type Extract = z.infer<typeof extractSchemas.Extract>;
  * Represents a list of extraction jobs
  */
 export type ExtractList = z.infer<typeof extractSchemas.ExtractList>; 
+
+/**
+ * Represents a rich transcript for a video
+ */
+export type RichTranscript = z.infer<typeof collectionsSchemas.RichTranscript>;
+
+


### PR DESCRIPTION
Concretely:
- pull latest api spec and generate code
- bump package version to 0.0.13
- adds collection type to new collection creation
- adds method for retrieving transcripts from rich transcript collection
- adds filter criteria based on url to list extracts and list transcribes
- adds filter criteria based on collection type to list collections
- removes old describe based api methods

Note currently pointing to sub module to commit here https://github.com/aviaryhq/cloudglue-api-spec/pull/9 while testing / until the upstream api spec change gets merged, will update this PR to pick up change from main branch when that is approved and merged