### PR TITLE
Add File Update to SDK

### DIFF
--- a/generated/Files.ts
+++ b/generated/Files.ts
@@ -31,11 +31,20 @@ const FileDelete = z
   .object({ id: z.string(), object: z.literal("file") })
   .strict()
   .passthrough();
+const FileUpdate = z
+  .object({
+    metadata: z.object({}).partial().strict().passthrough(),
+    filename: z.string(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
 
 export const schemas = {
   FileList,
   FileUpload,
   FileDelete,
+  FileUpdate,
 };
 
 const endpoints = makeApi([
@@ -190,6 +199,34 @@ const endpoints = makeApi([
       {
         status: 500,
         description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: "put",
+    path: "/files/:file_id",
+    alias: "updateFile",
+    description: `Update a file`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        description: `File update parameters`,
+        type: "Body",
+        schema: FileUpdate,
+      },
+      {
+        name: "file_id",
+        type: "Path",
+        schema: z.string(),
+      },
+    ],
+    response: CloudglueFile,
+    errors: [
+      {
+        status: 400,
+        description: `Invalid request or malformed file update parameters`,
         schema: z.object({ error: z.string() }).strict().passthrough(),
       },
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviaryhq/cloudglue-js",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviaryhq/cloudglue-js",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviaryhq/cloudglue-js",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,7 @@ import {
   TranscribeApi,
   ExtractApi,
 } from "../generated";
-import type { File } from "./types";
+import type { File, UpdateFileParams } from "./types";
 import { createApiClient as createFilesApiClient } from "../generated/Files";
 import { createApiClient as createCollectionsApiClient } from "../generated/Collections";
 import { createApiClient as createChatApiClient } from "../generated/Chat";
@@ -226,6 +226,13 @@ class EnhancedFilesApi {
     return this.api.deleteFile({ params: { file_id: fileId } } as any, {
       params: { file_id: fileId },
     });
+  }
+
+  async updateFile(fileId: string, params: UpdateFileParams) {
+    return this.api.updateFile(
+      params,
+      { params: { file_id: fileId } }
+    );
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export {
  */
 export type {
   File,
+  UpdateFileParams,
   Collection,
   CollectionFile,
   CollectionFileList,

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,15 @@ import { schemas as extractSchemas } from '../generated/Extract';
 export type { File } from '../generated/common';
 
 /**
+ * Parameters for updating an existing file
+ */
+export interface UpdateFileParams {
+  filename?: string;
+  metadata?: Record<string, any>;
+  [key: string]: any;
+}
+
+/**
  * Parameters for creating a new collection
  */
 export type NewCollectionParams = z.infer<typeof collectionsSchemas.NewCollection>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type { File } from '../generated/common';
 export interface UpdateFileParams {
   filename?: string;
   metadata?: Record<string, any>;
+  // Index signature allows additional properties to match the generated schema's .passthrough() behavior
   [key: string]: any;
 }
 


### PR DESCRIPTION
Add file update functionality to Cloudglue SDK

This PR adds support for the PUT /files/:file_id endpoint, allowing users to update existing files' filenames and metadata through the SDK. The implementation includes a new updateFile method in the EnhancedFilesApi class that accepts a file ID and update parameters.

The changes include adding an UpdateFileParams interface with optional filename and metadata fields, plus an index signature to match the generated schema's .passthrough() behavior. The new functionality is properly exported through the main SDK interface and follows the same patterns as existing API methods. Users can now update files with calls like client.files.updateFile('file-id', { filename: 'new-name.mp4', metadata: { description: 'updated' } }).