### PR TITLE
feat: add the sdk version and client into the headers when using the js sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "generate": "node generate.js",
-    "build": "tsc",
+    "build": "tsc && node scripts/build.js",
     "watch": "tsc --watch",
     "prepare": "npm run build"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,33 @@
+/**
+ * Use to do a build time replacement of the SDK version in the client.js and client.d.ts files
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Read package.json to get the version
+const packageJsonPath = path.join(__dirname, '..', 'package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const version = packageJson.version;
+
+console.log(`Building with SDK version: ${version}`);
+
+// Function to replace version placeholder in a file
+function replaceVersionInFile(filePath) {
+  if (fs.existsSync(filePath)) {
+    let content = fs.readFileSync(filePath, 'utf8');
+    content = content.replace(/__SDK_VERSION__/g, version);
+    fs.writeFileSync(filePath, content);
+    console.log(`Updated version in: ${filePath}`);
+  }
+}
+
+// Replace version in the built JavaScript file
+const jsFilePath = path.join(__dirname, '..', 'dist', 'src', 'client.js');
+replaceVersionInFile(jsFilePath);
+
+// Also replace in the TypeScript declaration file if it exists
+const dtsFilePath = path.join(__dirname, '..', 'dist', 'src', 'client.d.ts');
+replaceVersionInFile(dtsFilePath);
+
+console.log('Version replacement complete!');

--- a/src/client.ts
+++ b/src/client.ts
@@ -651,6 +651,8 @@ export class CloudGlue {
     const axiosConfig: AxiosRequestConfig = {
       headers: {
         Authorization: `Bearer ${this.apiKey}`,
+        'x-sdk-client': 'cloudglue-js',
+        'x-sdk-version': '__SDK_VERSION__',
       },
       baseURL: this.baseUrl,
       timeout: this.timeout,


### PR DESCRIPTION
- Adds the `x-sdk-client` and `x-sdk-version` to all header requests for the SDK
- updates the build script to do the inline replacement of the version at build time

### Example Request Headers
```
 {
   'x-sdk-client': 'cloudglue-js',
   'x-sdk-version': '0.1.3',
   'content-type': 'application/json',
   'user-agent': 'axios/1.8.4',
   'content-length': '350',
   'accept-encoding': 'gzip, compress, deflate, br',
   host: 'localhost:3002',
   connection: 'keep-alive'
 }
```