### PR TITLE
Introduce segment summaries to transcribe/collection output

### DIFF
--- a/generated/Collections.ts
+++ b/generated/Collections.ts
@@ -320,6 +320,20 @@ const RichTranscript = z
           .passthrough()
       )
       .optional(),
+    segment_summary: z
+      .array(
+        z
+          .object({
+            title: z.string(),
+            summary: z.string(),
+            start_time: z.number(),
+            end_time: z.number(),
+          })
+          .partial()
+          .strict()
+          .passthrough()
+      )
+      .optional(),
   })
   .strict()
   .passthrough();
@@ -397,6 +411,18 @@ const CollectionRichTranscriptsList = z
                 z
                   .object({
                     text: z.string(),
+                    start_time: z.number(),
+                    end_time: z.number(),
+                  })
+                  .partial()
+                  .strict()
+                  .passthrough()
+              ),
+              segment_summary: z.array(
+                z
+                  .object({
+                    title: z.string(),
+                    summary: z.string(),
                     start_time: z.number(),
                     end_time: z.number(),
                   })

--- a/generated/Transcribe.ts
+++ b/generated/Transcribe.ts
@@ -45,6 +45,14 @@ type Transcribe = {
             end_time: number;
           }>
         >;
+        segment_summary: Array<
+          Partial<{
+            title: string;
+            summary: string;
+            start_time: number;
+            end_time: number;
+          }>
+        >;
       }>
     | undefined;
   error?: string | undefined;
@@ -128,6 +136,18 @@ const Transcribe: z.ZodType<Transcribe> = z
           z
             .object({
               text: z.string(),
+              start_time: z.number(),
+              end_time: z.number(),
+            })
+            .partial()
+            .strict()
+            .passthrough()
+        ),
+        segment_summary: z.array(
+          z
+            .object({
+              title: z.string(),
+              summary: z.string(),
               start_time: z.number(),
               end_time: z.number(),
             })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviaryhq/cloudglue-js",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviaryhq/cloudglue-js",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "Elastic-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviaryhq/cloudglue-js",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Changes
- updates api spec to latest change in https://github.com/aviaryhq/cloudglue-api-spec/commit/51ffbf9d58d7325e5ea53b80ca4b6d5853326561
- re generates types used for rich transcripts in collections and transcribes to introduce segment_summary concept in results
- bump package version to 0.1.6