### PR TITLE
refactor: changes the export of filter as a type to a enum correctly

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -9,7 +9,7 @@ import {
   DescribeApi,
   SegmentsApi,
 } from "../generated";
-import { FilterOperator } from "./types";
+import { FilterOperator } from "./enums";
 import type { File, NarrativeConfig, SegmentationConfig, ShotConfig, UpdateFileParams } from "./types";
 import { createApiClient as createFilesApiClient } from "../generated/Files";
 import { createApiClient as createCollectionsApiClient } from "../generated/Collections";

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,14 @@
+/**
+ * Filter operators for metadata, video info, and file property filtering
+ * Used across different APIs for consistent filtering behavior
+ */
+export enum FilterOperator {
+  NotEqual = "NotEqual",
+  Equal = "Equal",
+  LessThan = "LessThan",
+  GreaterThan = "GreaterThan",
+  ContainsAny = "ContainsAny",
+  ContainsAll = "ContainsAll",
+  In = "In",
+  Like = "Like"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,5 @@ export * from '../generated';
  * Common type definitions used throughout the SDK
  */
 export type * from './types';
+
+export * from './enums';

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,20 +15,6 @@ import { SegmentationUniformConfig as SegmentationUniformConfigType, Segmentatio
  * Contains metadata about the file including its status, size, and video information
  */
 export type { File } from '../generated/common';
-/**
- * Filter operators for metadata, video info, and file property filtering
- * Used across different APIs for consistent filtering behavior
- */
-export enum FilterOperator {
-  NotEqual = "NotEqual",
-  Equal = "Equal",
-  LessThan = "LessThan",
-  GreaterThan = "GreaterThan",
-  ContainsAny = "ContainsAny",
-  ContainsAll = "ContainsAll",
-  In = "In",
-  Like = "Like"
-}
 
 
 /**


### PR DESCRIPTION
- previously was exported as a type, which meant using the sdk, we can't do things like `FilterOperator.Equal`