### PR TITLE
pull latest api spec and bump package version

### DIFF
--- a/generated/Collections.ts
+++ b/generated/Collections.ts
@@ -330,6 +330,7 @@ const RichTranscript = z
       .array(
         z
           .object({
+            speaker: z.string(),
             text: z.string(),
             start_time: z.number(),
             end_time: z.number(),
@@ -433,6 +434,7 @@ const CollectionRichTranscriptsList = z
               speech: z.array(
                 z
                   .object({
+                    speaker: z.string(),
                     text: z.string(),
                     start_time: z.number(),
                     end_time: z.number(),
@@ -506,6 +508,7 @@ const CollectionMediaDescriptionsList = z
               speech: z.array(
                 z
                   .object({
+                    speaker: z.string(),
                     text: z.string(),
                     start_time: z.number(),
                     end_time: z.number(),
@@ -573,6 +576,7 @@ const MediaDescription = z
       .array(
         z
           .object({
+            speaker: z.string(),
             text: z.string(),
             start_time: z.number(),
             end_time: z.number(),

--- a/generated/Describe.ts
+++ b/generated/Describe.ts
@@ -27,6 +27,7 @@ type Describe = {
         summary: string;
         speech: Array<
           Partial<{
+            speaker: string;
             text: string;
             start_time: number;
             end_time: number;
@@ -116,6 +117,7 @@ const Describe: z.ZodType<Describe> = z
         speech: z.array(
           z
             .object({
+              speaker: z.string(),
               text: z.string(),
               start_time: z.number(),
               end_time: z.number(),

--- a/generated/Search.ts
+++ b/generated/Search.ts
@@ -60,6 +60,7 @@ type SegmentSearchResult = {
   speech?:
     | Array<
         Partial<{
+          speaker: string;
           text: string;
           start_time: number;
           end_time: number;
@@ -159,7 +160,7 @@ const FileSearchResult: z.ZodType<FileSearchResult> = z
     file_id: z.string().uuid(),
     collection_id: z.string().uuid(),
     id: z.string().uuid(),
-    score: z.number().gte(0).lte(1),
+    score: z.number(),
     filename: z.string().nullish(),
     summary: z.string().nullish(),
     generated_title: z.string().nullish(),
@@ -174,7 +175,7 @@ const SegmentSearchResult: z.ZodType<SegmentSearchResult> = z
     collection_id: z.string().uuid(),
     segment_id: z.string().uuid(),
     id: z.string().uuid(),
-    score: z.number().gte(0).lte(1),
+    score: z.number(),
     start_time: z.number(),
     end_time: z.number(),
     title: z.string().nullish(),
@@ -209,6 +210,7 @@ const SegmentSearchResult: z.ZodType<SegmentSearchResult> = z
       .array(
         z
           .object({
+            speaker: z.string(),
             text: z.string(),
             start_time: z.number(),
             end_time: z.number(),

--- a/generated/Transcribe.ts
+++ b/generated/Transcribe.ts
@@ -27,6 +27,7 @@ type Transcribe = {
         summary: string;
         speech: Array<
           Partial<{
+            speaker: string;
             text: string;
             start_time: number;
             end_time: number;
@@ -116,6 +117,7 @@ const Transcribe: z.ZodType<Transcribe> = z
         speech: z.array(
           z
             .object({
+              speaker: z.string(),
               text: z.string(),
               start_time: z.number(),
               end_time: z.number(),

--- a/generated/common.ts
+++ b/generated/common.ts
@@ -19,6 +19,7 @@ export type SegmentationUniformConfig = {
   hop_seconds?: number | undefined;
 };
 export type SegmentationShotDetectorConfig = {
+  threshold?: (number | null) | undefined;
   min_seconds?: (number | null) | undefined;
   max_seconds?: (number | null) | undefined;
   detector: "adaptive" | "content";
@@ -98,6 +99,7 @@ export const SegmentationUniformConfig = z
   .passthrough();
 export const SegmentationShotDetectorConfig = z
   .object({
+    threshold: z.number().nullish(),
     min_seconds: z.number().gte(2).lte(60).nullish(),
     max_seconds: z.number().gte(2).lte(60).nullish(),
     detector: z.enum(["adaptive", "content"]),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviaryhq/cloudglue-js",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviaryhq/cloudglue-js",
-      "version": "0.2.5",
+      "version": "0.3.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",
@@ -548,9 +548,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviaryhq/cloudglue-js",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
changes:
- pick up latest api spec and regenerate low level sdk code (most notable difference is speaker now included in speech response types)
- bump version of sdk to match api spec version (will follow from now on / append sdk specific suffixes if changes are not originating from feature changes in cloudglue API)