### PR TITLE
Add grain data connector filter options and resolve typescript deprecation  issues. 

### DIFF
--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -4,7 +4,7 @@ Browse files available in connected external data sources. Data connectors are c
 
 ## Supported Connectors
 
-S3, Google Cloud Storage (GCS), Dropbox, Google Drive, Zoom, Gong, Recall
+S3, Google Cloud Storage (GCS), Dropbox, Google Drive, Zoom, Gong, Recall, Grain
 
 ## List Connectors
 
@@ -25,6 +25,9 @@ const files = await client.dataConnectors.listFiles(connectorId, {
   path: '/recordings/',        // path-based sources
   bucket: 'my-bucket',        // S3, GCS
   prefix: 'videos/',          // S3, GCS
+  title_search: 'video-title', // Grain
+  team: 'team-name',           // Grain
+  meeting_type: 'type-123'     // Grain
 });
 ```
 

--- a/generated/Data_Connectors.ts
+++ b/generated/Data_Connectors.ts
@@ -11,7 +11,15 @@ type DataConnectorList = {
 type DataConnector = {
   id: string;
   object: 'data_connector';
-  type: 's3' | 'dropbox' | 'google-drive' | 'zoom' | 'gong' | 'recall' | 'gcs';
+  type:
+    | 's3'
+    | 'dropbox'
+    | 'google-drive'
+    | 'zoom'
+    | 'gong'
+    | 'recall'
+    | 'gcs'
+    | 'grain';
   created_at: number;
   updated_at: number;
   metadata: {};
@@ -53,6 +61,7 @@ const DataConnector: z.ZodType<DataConnector> = z
       'gong',
       'recall',
       'gcs',
+      'grain',
     ]),
     created_at: z.number().int(),
     updated_at: z.number().int(),
@@ -169,6 +178,21 @@ const endpoints = makeApi([
       },
       {
         name: 'prefix',
+        type: 'Query',
+        schema: z.string().optional(),
+      },
+      {
+        name: 'title_search',
+        type: 'Query',
+        schema: z.string().optional(),
+      },
+      {
+        name: 'team',
+        type: 'Query',
+        schema: z.string().optional(),
+      },
+      {
+        name: 'meeting_type',
         type: 'Query',
         schema: z.string().optional(),
       },

--- a/generated/common.ts
+++ b/generated/common.ts
@@ -149,6 +149,7 @@ export type File = {
         | 'gong'
         | 'recall'
         | 'gcs'
+        | 'grain'
       )
     | undefined;
 };
@@ -487,6 +488,7 @@ export const File = z
         'gong',
         'recall',
         'gcs',
+        'grain',
       ])
       .optional(),
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.8.0",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.8.0",
+      "version": "0.7.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.7",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.7",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.7",
+  "version": "0.8.0",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.8.0",
+  "version": "0.7.8",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/data-connectors.api.ts
+++ b/src/api/data-connectors.api.ts
@@ -17,6 +17,12 @@ export interface ListDataConnectorFilesParams {
   bucket?: string;
   /** Filter by key prefix (S3, GCS) */
   prefix?: string;
+  /** Filter by title (Grain) */
+  title_search?: string;
+  /** Filter by team (Grain) */
+  team?: string;
+  /** Filter by meeting type (Grain) */
+  meeting_type?: string;
 }
 
 export class EnhancedDataConnectorsApi {

--- a/src/api/files.api.ts
+++ b/src/api/files.api.ts
@@ -9,6 +9,8 @@ import {
 } from '../types';
 import { CloudglueError } from '../error';
 
+import type { AxiosResponse } from 'axios';
+
 type UploadFileParams = {
   file: globalThis.File;
   metadata?: Record<string, any>;
@@ -68,7 +70,7 @@ export class EnhancedFilesApi {
     }
 
     // Use axios directly to bypass Zodios validation
-    return this.api.axios({
+    return this.api.axios<AxiosResponse<File>>({
       method: 'post',
       url: '/files',
       data: formData,

--- a/src/api/files.api.ts
+++ b/src/api/files.api.ts
@@ -41,7 +41,7 @@ export class EnhancedFilesApi {
     return this.api.listFiles({ queries });
   }
 
-  async uploadFile(params: UploadFileParams) {
+  async uploadFile(params: UploadFileParams): Promise<AxiosResponse> {
     // File uploads require special handling for multipart/form-data that the generated Zodios client doesn't handle automatically.
     // We need to:
     // 1. Create a FormData object and append the file with the correct field name
@@ -70,7 +70,7 @@ export class EnhancedFilesApi {
     }
 
     // Use axios directly to bypass Zodios validation
-    return this.api.axios<AxiosResponse<File>>({
+    return this.api.axios({
       method: 'post',
       url: '/files',
       data: formData,

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import type { AxiosRequestConfig } from 'axios';
 import type { CloudglueConfig } from './types';
 import { createApiClient as createFilesApiClient } from '../generated/Files';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,14 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "Node16",
+    "module": "commonjs",
     "declaration": true,
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "Node16",
-    "types": ["node"]
+    "moduleResolution": "bundler"
   },
   "include": ["generated/**/*", "src/**/*", "env.d.ts"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "commonjs",
+    "module": "Node16",
     "declaration": true,
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node"
+    "moduleResolution": "Node16",
+    "types": ["node"]
   },
   "include": ["generated/**/*", "src/**/*", "env.d.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
# Summary 
This PR updates the js sdk to include the grain data connector.  
- Added three new filter options to  the ListDataConnectorFilesParams
- updated package.json to resolve depreciated legacy settings build issue. 
- Minor version bump to 0.7.8 


## Build issue
[article](https://visualstudiomagazine.com/articles/2026/03/23/typescript-6-0-ships-as-final-javascript-based-release-clears-path-for-go-native-7-0.aspx#:~:text=Microsoft%20on%20March%2023%20released,in%20the%20Go%20programming%20language.)
[ref](https://www.typescriptlang.org/tsconfig/#moduleResolution)

to fix this in the narrowest way possible we have opted to follow this [advice](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/#combining---moduleresolution-bundler-with---module-commonjs) and this [advice](https://github.com/microsoft/TypeScript/pull/62320) 


## Testing
- node - ensured sdk is importable and runnable on local node.  
```
cd {common-js directory}
run node
const { Cloudglue } = require('./dist/src/index.js')
const client = new Cloudglue({ apiKey: 'not my real api key'})
const myFiles = await client.files.listFiles({limit: 10});
console.log(myFiles)
{
  object: 'list',
  data: [
    {
      id: '****************',
      object: 'file',
      bytes: 148648709,
...
```

-Browser - setup simple vita app ensure we can install, import and use common-js
main.ts
```
import { Cloudglue } from '@cloudglue/cloudglue-js';

// Smoke: constructor only (no network). Use a real key + API calls to test CORS.
const _client = new Cloudglue({ apiKey: 'browser-smoke-not-a-real-key' });
console.info('Cloudglue client OK', _client.files != null);
```
in browser we see: Cloudglue client OK true

- ensure filters are working - tested limit, meeting_type, from, to filters from sdk in the following way: 
```
const client = new Cloudglue({ apiKey: "1234567890", baseUrl: "http://localhost:3002/v1"});
const dataConnectors = await client.dataConnectors.list();
const grain = dataConnectors.data[0];
const params = { 
  limit: 10,
};
const files = await client.dataConnectors.listFiles(grain.id, params);
console.info('Cloudglue client OK', files); 
```
and received successful responses. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Grain data connector with new filtering capabilities for connector file operations.
  * Introduced three new optional filters: title search, team, and meeting type.

* **Documentation**
  * Updated data connector documentation to reflect Grain connector support and usage examples.

* **Chores**
  * Version updated to 0.8.0.
  * Enhanced type safety and optimized build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->