### PR TITLE
feat: add loom

### DIFF
--- a/generated/common.ts
+++ b/generated/common.ts
@@ -150,6 +150,7 @@ export type File = {
         | 'recall'
         | 'gcs'
         | 'grain'
+        | 'loom'
       )
     | undefined;
 };
@@ -489,6 +490,7 @@ export const File = z
         'recall',
         'gcs',
         'grain',
+        'loom',
       ])
       .optional(),
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
# Summary 
Update SDK to addloom to the source enum schema .  This supports https://github.com/makeyolo/cloudglue/pull/1094

# Changes 
- [x] Include Loom as a valid source response in generated files from updated openapi file. 
- [x] minor update version from 0.7.9 to 0.7.10
- [x] update package-lock.json
- [x] update submodule after https://github.com/cloudglue/cloudglue-api-spec/pull/94 merged

# Testing
- [x] Import local updated sdk and tested client.files.getFile for loom file.  Verified source came back as loom.
- [x] Visually verify package lock  update is version only
- [x] Regenerate and ensure no changes. Visually verify submodule is clooudglue-api-spec 0.7.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.7.10
  * Internal dependencies updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->