### PR TITLE
chore: update embedded docs for Cloudglue data sources

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -32,7 +32,7 @@ await client.collections.addMedia(collectionId, fileId, {
   // Optional: override collection-level configs for this file
 });
 
-// Add by URL (CloudGlue will download and process)
+// Add by URL (Cloudglue will download and process)
 await client.collections.addMediaByUrl({
   collectionId,
   url: 'https://example.com/video.mp4',

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -1,6 +1,6 @@
 # Data Connectors API
 
-Browse files available in connected external data sources. Data connectors are configured in the CloudGlue dashboard — this API lets you list connectors and browse their files.
+Browse files available in connected external data sources. Data connectors are configured in the Cloudglue dashboard — this API lets you list connectors and browse their files.
 
 ## Supported Connectors
 
@@ -31,4 +31,4 @@ const files = await client.dataConnectors.listFiles(connectorId, {
 });
 ```
 
-Files returned include URIs compatible with CloudGlue's import system — use them with `client.collections.addMediaByUrl()` or `client.describe.createDescribe()`.
+Files returned include URIs compatible with Cloudglue's import system — use them with `client.collections.addMediaByUrl()` or `client.describe.createDescribe()`.

--- a/docs/files.md
+++ b/docs/files.md
@@ -1,6 +1,6 @@
 # Files API
 
-Manage video and audio files in CloudGlue.
+Manage video and audio files in Cloudglue.
 
 ## Upload a File
 

--- a/docs/other-sources.md
+++ b/docs/other-sources.md
@@ -4,7 +4,7 @@ Use any publicly available video URL directly with Cloudglue. Accepted by most A
 
 ## Supported URLs
 
-Video urls that point to a video file, as well as, public YouTube, TikTok, and Loom urls. 
+Video URLs that point to a video file, as well as public YouTube, TikTok, and Loom URLs. 
 
 ## Using URLs with Cloudglue
 

--- a/docs/other-sources.md
+++ b/docs/other-sources.md
@@ -1,0 +1,20 @@
+# Other Sources
+
+Use any publicly available video URL directly with Cloudglue. Accepted by most API endpoints that operate on a video.
+
+## Supported URLs
+
+Video urls that point to a video file, as well as, public YouTube, TikTok, and Loom urls. 
+
+## Using URLs with Cloudglue
+
+```typescript
+const url = `https://www.loom.com/share/12345678901234567890123456789012`
+
+const description = await client.describe.createDescribe(url, {
+  enable_summary: true,
+  enable_speech: true,
+  enable_scene_text: true,
+  enable_visual_scene_description: true,
+});
+```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,17 +1,17 @@
-# CloudGlue JS SDK
+# Cloudglue JS SDK
 
-CloudGlue turns video into LLM-ready data. This SDK (`@cloudglue/cloudglue-js`) provides type-safe TypeScript clients for uploading, analyzing, searching, and querying video content.
+Cloudglue turns video into LLM-ready data. This SDK (`@cloudglue/cloudglue-js`) provides type-safe TypeScript clients for uploading, analyzing, searching, and querying video content.
 
 ## Mental Model
 
 ```text
-Files (upload video/audio)
+Files (upload video/audio, video URL, data connector URI)
   → Processing (describe, extract, face detection)
     → Collections (group processed files)
       → Querying (chat, search, deep search, responses API)
 ```
 
-1. **Upload** a video file or provide a URL
+1. **Upload** a video file, provide a URL, or provide a data connector URI
 2. **Process** it with describe (multimodal descriptions) or extract (structured data)
 3. **Organize** files into collections
 4. **Query** collections via chat, search, deep search, or the Responses API


### PR DESCRIPTION
# Summary 
Bring embedded documentation up to date with current Data Connector and Data Sources in Cloudglue.  It seems at some point Other Sources forked off Data Connectors and this was not captured in this repo.  

fixes ENG-921

# Changes
- Add a specific file for other sources which include https, Loom, TikTok, YouTube
- Update copy to Cloudglue 

# Testing 
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for using publicly accessible video URLs (YouTube, TikTok, Loom, direct links)
  * Updated overview to reflect expanded input options: upload media, provide URL, or use data connector
  * Clarified file URI compatibility with the import system
  * Standardized product branding across documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloudglue/cloudglue-js/pull/119)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->