### PR TITLE
Grain source metadata: spec bump + nullish/nullable transform fixes

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -179,7 +179,12 @@ for (const file of generatedFiles) {
         const nullishIndex = match.index;
         // Look backwards from .nullish()/.nullable() to find the field name
         // We're looking for: field_name: z... or field_name: SomeType...
-        const beforeNullish = fileContent.substring(Math.max(0, nullishIndex - 1000), nullishIndex);
+        // Align the 1000-char window to a line boundary so it never begins
+        // mid-line — otherwise the `^` anchor in the regexes below could match a
+        // truncated line fragment as a line-start field and pick a false owner.
+        const rawStart = Math.max(0, nullishIndex - 1000);
+        const windowStart = rawStart === 0 ? 0 : fileContent.lastIndexOf('\n', rawStart) + 1;
+        const beforeNullish = fileContent.substring(windowStart, nullishIndex);
         // Get the indent level of the .nullish() line
         const lineStart = fileContent.lastIndexOf('\n', nullishIndex - 1) + 1;
         const lineBeforeNullish = fileContent.substring(lineStart, nullishIndex);

--- a/generate.js
+++ b/generate.js
@@ -189,8 +189,12 @@ for (const file of generatedFiles) {
         // Pattern matches: field_name: z (with newline and whitespace before a dot, or directly z.)
         // Handles both z\n      .object() and z.object() styles
         const fieldMatches = [...beforeNullish.matchAll(/(?:^|\n|,)(\s*)(\w+)\s*:\s*z\s*\n\s*\./g)];
-        // Also match single-line z.field() patterns
-        const singleLineMatches = [...beforeNullish.matchAll(/(?:^|\n|,)(\s*)(\w+)\s*:\s*z\./g)];
+        // Also match single-line z.field() patterns.
+        // Anchor to line-start only (no `,`): top-level fields are always on their
+        // own line, whereas comma-preceded matches are inline object members
+        // (e.g. `name`/`scope` in `z.object({ id: ..., name: ..., scope: ... })`)
+        // which would otherwise be mistaken for the nullish field.
+        const singleLineMatches = [...beforeNullish.matchAll(/(?:^|\n)(\s*)(\w+)\s*:\s*z\./g)];
         fieldMatches.push(...singleLineMatches);
         
         if (fieldMatches.length > 0) {
@@ -349,8 +353,15 @@ for (const file of generatedFiles) {
     const lines = fileContent.split('\n');
     for (let i = 0; i < lines.length; i++) {
         if (lines[i].includes('.nullable()')) {
+            // The owning field is indented at most as much as its `.nullable()`
+            // line; inner sub-fields of the object (e.g. `user_id` inside an
+            // `assignee` object) are indented MORE. Skip those deeper matches so
+            // we attribute `.nullable()` to the real field, not a nested one.
+            const nullableIndent = (lines[i].match(/^(\s*)/) || ['', ''])[1].length;
             // Walk backwards to find the field name
             for (let j = i; j >= Math.max(0, i - 20); j--) {
+                const indent = (lines[j].match(/^(\s*)/) || ['', ''])[1].length;
+                if (indent > nullableIndent) continue;
                 const fieldMatch = lines[j].match(/^\s+(\w+):\s*(?:z\b|z\s*$)/);
                 if (fieldMatch) {
                     nullableObjFields.add(fieldMatch[1]);

--- a/generated/Collections.ts
+++ b/generated/Collections.ts
@@ -9,6 +9,8 @@ import { NarrativeConfig } from './common';
 import { KeyframeConfig } from './common';
 import { ThumbnailsConfig } from './common';
 import { File } from './common';
+import { SourceMetadata } from './common';
+import { GrainSourceMetadata } from './common';
 import { DescribeOutput } from './common';
 import { DescribeOutputPart } from './common';
 import { SpeechOutputPart } from './common';

--- a/generated/Data_Connectors.ts
+++ b/generated/Data_Connectors.ts
@@ -1,6 +1,10 @@
 import { makeApi, Zodios, type ZodiosOptions } from '@zodios/core';
 import { z } from 'zod';
 
+import { File } from './common';
+import { SourceMetadata } from './common';
+import { GrainSourceMetadata } from './common';
+
 type DataConnectorList = {
   object: 'list';
   data: Array<DataConnector>;
@@ -47,6 +51,10 @@ type DataConnectorFile = {
       [key: string]: any;
     }
   >;
+};
+type SourceMetadataResponse = {
+  object: 'source_metadata';
+  source_metadata: SourceMetadata;
 };
 
 const DataConnector: z.ZodType<DataConnector> = z
@@ -105,12 +113,20 @@ const DataConnectorFileList: z.ZodType<DataConnectorFileList> = z
   })
   .strict()
   .passthrough();
+const SourceMetadataResponse: z.ZodType<SourceMetadataResponse> = z
+  .object({
+    object: z.literal('source_metadata'),
+    source_metadata: SourceMetadata,
+  })
+  .strict()
+  .passthrough();
 
 export const schemas = {
   DataConnector,
   DataConnectorList,
   DataConnectorFile,
   DataConnectorFileList,
+  SourceMetadataResponse,
 };
 
 const endpoints = makeApi([
@@ -212,6 +228,90 @@ const endpoints = makeApi([
       {
         status: 500,
         description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 502,
+        description: `Error communicating with the external service`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'post',
+    path: '/data-connectors/:id/sync',
+    alias: 'syncDataConnectorFile',
+    description: `Materialize a connector URI (e.g. &#x60;grain://recording/&lt;id&gt;&#x60;) into a Cloudglue file without starting a downstream job. Idempotent: syncing the same URI returns the existing file. For Grain, the file&#x27;s &#x60;source_metadata&#x60; is populated from the recording.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'body',
+        type: 'Body',
+        schema: z.object({ url: z.string() }).strict().passthrough(),
+      },
+      {
+        name: 'id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: File,
+    errors: [
+      {
+        status: 400,
+        description: `Bad request (e.g. URL source does not match the connector type)`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 404,
+        description: `Data connector not found`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 500,
+        description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 502,
+        description: `Error communicating with the external service`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'get',
+    path: '/data-connectors/:id/source-metadata',
+    alias: 'getDataConnectorSourceMetadata',
+    description: `Fetch source metadata for a connector URI directly from the upstream source, without creating a Cloudglue file. Currently supported for Grain; other connector types return 501.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+      {
+        name: 'url',
+        type: 'Query',
+        schema: z.string(),
+      },
+    ],
+    response: SourceMetadataResponse,
+    errors: [
+      {
+        status: 400,
+        description: `Bad request (e.g. URL source does not match the connector type)`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 404,
+        description: `Data connector not found`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 501,
+        description: `Source metadata lookup is not implemented for this connector type`,
         schema: z.object({ error: z.string() }).strict().passthrough(),
       },
       {

--- a/generated/Files.ts
+++ b/generated/Files.ts
@@ -1,7 +1,7 @@
 import { makeApi, Zodios, type ZodiosOptions } from '@zodios/core';
 import { z } from 'zod';
 import { File as CloudglueFile } from "./common";
-import { Segmentation, SegmentationConfig, SegmentationUniformConfig, SegmentationShotDetectorConfig, SegmentationManualConfig, NarrativeConfig, KeyframeConfig, ThumbnailsConfig, Shot, Chapter, ThumbnailList, Thumbnail, ThumbnailType, ListVideoTagsResponse, PaginationResponse, VideoTag, FrameExtraction, FrameExtractionConfig, FrameExtractionUniformConfig, FrameExtractionThumbnailsConfig } from "./common";
+import { SourceMetadata, GrainSourceMetadata, Segmentation, SegmentationConfig, SegmentationUniformConfig, SegmentationShotDetectorConfig, SegmentationManualConfig, NarrativeConfig, KeyframeConfig, ThumbnailsConfig, Shot, Chapter, ThumbnailList, Thumbnail, ThumbnailType, ListVideoTagsResponse, PaginationResponse, VideoTag, FrameExtraction, FrameExtractionConfig, FrameExtractionUniformConfig, FrameExtractionThumbnailsConfig } from "./common";
 
 type FileList = {
   object: 'list';

--- a/generated/common.ts
+++ b/generated/common.ts
@@ -135,7 +135,7 @@ export type File = {
         has_audio: boolean | null;
       }>
     | undefined;
-  thumbnail_url?: string | undefined;
+  thumbnail_url?: (string | null) | undefined;
   source?:
     | (
         | 'video'
@@ -152,6 +152,89 @@ export type File = {
         | 'grain'
         | 'loom'
       )
+    | null
+    | undefined;
+  source_metadata?: (SourceMetadata | null) | undefined;
+};
+export type SourceMetadata = GrainSourceMetadata;
+export type GrainSourceMetadata = {
+  source_type: 'grain';
+  grain_recording_id: string;
+  title: string;
+  start_datetime: string;
+  end_datetime: string;
+  duration_ms: number;
+  media_type: 'audio' | 'transcript' | 'video';
+  upstream_source:
+    | 'aircall'
+    | 'local_capture'
+    | 'meet'
+    | 'teams'
+    | 'upload'
+    | 'webex'
+    | 'zoom'
+    | 'other';
+  grain_url: string;
+  thumbnail_url?: (string | null) | undefined;
+  tags: Array<string>;
+  teams: Array<
+    Partial<{
+      id: string;
+      name: string;
+    }>
+  >;
+  meeting_type?:
+    | Partial<{
+        id: string;
+        name: string;
+        scope: string;
+      }>
+    | null
+    | undefined;
+  participants?:
+    | Array<
+        Partial<{
+          id: string;
+          name: string;
+          email: string | null;
+          scope: 'internal' | 'external' | 'unknown';
+          confirmed_attendee: boolean;
+          hs_contact_id: string | null;
+        }>
+      >
+    | undefined;
+  highlights?: Array<{}> | undefined;
+  ai_summary?:
+    | Partial<{
+        text: string;
+      }>
+    | undefined;
+  ai_action_items?:
+    | Array<
+        Partial<{
+          status: 'pending' | 'completed';
+          timestamp_ms: number;
+          text: string;
+          assignee: Partial<{
+            id: string;
+            name: string;
+            user_id: string | null;
+          }> | null;
+        }>
+      >
+    | undefined;
+  ai_template_sections?: Array<{}> | undefined;
+  calendar_event?:
+    | Partial<{
+        ical_uid: string;
+      }>
+    | null
+    | undefined;
+  hubspot?:
+    | Partial<{
+        hubspot_company_ids: Array<string>;
+        hubspot_deal_ids: Array<string>;
+      }>
     | undefined;
 };
 export type Describe = {
@@ -159,7 +242,7 @@ export type Describe = {
   status: 'pending' | 'processing' | 'completed' | 'failed' | 'not_applicable';
   url?: string | undefined;
   duration_seconds?: (number | null) | undefined;
-  thumbnail_url?: string | undefined;
+  thumbnail_url?: (string | null) | undefined;
   created_at?: number | undefined;
   describe_config?:
     | Partial<{
@@ -233,7 +316,7 @@ export type Segmentation = {
               id: string;
               start_time: number;
               end_time: number;
-              thumbnail_url?: string | undefined;
+              thumbnail_url?: (string | null) | undefined;
             }>
           | undefined;
         shots?: Array<Shot> | undefined;
@@ -283,7 +366,7 @@ export type FrameExtraction = {
           | Array<{
               id: string;
               timestamp: number;
-              thumbnail_url?: string | undefined;
+              thumbnail_url?: (string | null) | undefined;
             }>
           | undefined;
         total: number;
@@ -432,6 +515,111 @@ export const FileSegmentationConfig = z
   .partial()
   .strict()
   .passthrough();
+export const GrainSourceMetadata = z
+  .object({
+    source_type: z.literal('grain'),
+    grain_recording_id: z.string(),
+    title: z.string(),
+    start_datetime: z.string().datetime({ offset: true }),
+    end_datetime: z.string().datetime({ offset: true }),
+    duration_ms: z.number().int(),
+    media_type: z.enum(['audio', 'transcript', 'video']),
+    upstream_source: z.enum([
+      'aircall',
+      'local_capture',
+      'meet',
+      'teams',
+      'upload',
+      'webex',
+      'zoom',
+      'other',
+    ]),
+    grain_url: z.string(),
+    thumbnail_url: z.string().nullish(),
+    tags: z.array(z.string()),
+    teams: z.array(
+      z
+        .object({ id: z.string(), name: z.string() })
+        .partial()
+        .strict()
+        .passthrough()
+    ),
+    meeting_type: z
+      .object({ id: z.string(), name: z.string(), scope: z.string() })
+      .partial()
+      .strict()
+      .passthrough()
+      .nullish(),
+    participants: z
+      .array(
+        z
+          .object({
+            id: z.string(),
+            name: z.string(),
+            email: z.string().nullable(),
+            scope: z.enum(['internal', 'external', 'unknown']),
+            confirmed_attendee: z.boolean(),
+            hs_contact_id: z.string().nullable(),
+          })
+          .partial()
+          .strict()
+          .passthrough()
+      )
+      .optional(),
+    highlights: z
+      .array(z.object({}).partial().strict().passthrough())
+      .optional(),
+    ai_summary: z
+      .object({ text: z.string() })
+      .partial()
+      .strict()
+      .passthrough()
+      .optional(),
+    ai_action_items: z
+      .array(
+        z
+          .object({
+            status: z.enum(['pending', 'completed']),
+            timestamp_ms: z.number().int(),
+            text: z.string(),
+            assignee: z
+              .object({
+                id: z.string(),
+                name: z.string(),
+                user_id: z.string().nullable(),
+              })
+              .partial()
+              .strict()
+              .passthrough()
+              .nullable(),
+          })
+          .partial()
+          .strict()
+          .passthrough()
+      )
+      .optional(),
+    ai_template_sections: z
+      .array(z.object({}).partial().strict().passthrough())
+      .optional(),
+    calendar_event: z
+      .object({ ical_uid: z.string() })
+      .partial()
+      .strict()
+      .passthrough()
+      .nullish(),
+    hubspot: z
+      .object({
+        hubspot_company_ids: z.array(z.string()),
+        hubspot_deal_ids: z.array(z.string()),
+      })
+      .partial()
+      .strict()
+      .passthrough()
+      .optional(),
+  })
+  .strict()
+  .passthrough();
+export const SourceMetadata = GrainSourceMetadata;
 export const File = z
   .object({
     id: z.string(),
@@ -493,6 +681,7 @@ export const File = z
         'loom',
       ])
       .optional(),
+    source_metadata: SourceMetadata.nullish(),
   })
   .strict()
   .passthrough();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",
@@ -953,9 +953,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/data-connectors.api.ts
+++ b/src/api/data-connectors.api.ts
@@ -47,4 +47,37 @@ export class EnhancedDataConnectorsApi {
       queries: params,
     });
   }
+
+  /**
+   * Fetch source metadata for a connector URI directly from the upstream
+   * source, without creating a Cloudglue file. Currently supported for Grain;
+   * other connector types return 501.
+   *
+   * @param connectorId - The ID of the data connector
+   * @param url - Connector URI to look up (must match the connector's type)
+   * @returns The source metadata for the URI
+   */
+  async getSourceMetadata(connectorId: string, url: string) {
+    return this.api.getDataConnectorSourceMetadata({
+      params: { id: connectorId },
+      queries: { url },
+    });
+  }
+
+  /**
+   * Materialize a connector URI (e.g. `grain://recording/<id>`) into a
+   * Cloudglue file without starting a downstream job. Idempotent: syncing the
+   * same URI returns the existing file. For Grain, the file's `source_metadata`
+   * is populated from the recording.
+   *
+   * @param connectorId - The ID of the data connector
+   * @param url - Connector URI to sync (must match the connector's type)
+   * @returns The resulting Cloudglue file
+   */
+  async syncFile(connectorId: string, url: string) {
+    return this.api.syncDataConnectorFile(
+      { url },
+      { params: { id: connectorId } },
+    );
+  }
 }


### PR DESCRIPTION
## Summary
Regenerates the SDK clients from the latest OpenAPI spec (adds **grain source metadata** plus two new data-connector endpoints), fixes two latent bugs in the post-generation transform (`generate.js`) that the new schema exposed (breaking `npm run build`), and surfaces the new endpoints in the high-level wrapper.

## Root cause (build break)
The backward field-name detection in `generate.js` didn't account for nested/inline object members, so `.nullish()`/`.nullable()` was attributed to the wrong field — leaving the TS type without `| null` while the Zod schema produced it.

## Fixes
- **`meeting_type` (`.nullish()`)** — the single-line field regex matched comma-preceded inline object props (`name`/`scope` inside `z.object({ id, name, scope })`), latching onto `scope` instead of `meeting_type`. Anchored the regex to line-start only.
- **`ai_action_items[].assignee` (`.nullable()`)** — the backward walk took the first `field: z` line it found, which was the inner `user_id`, never reaching `assignee`. Added an indentation guard so deeper sub-fields don't shadow their parent.
- **Backward-search window alignment** — the 1000-char window could start mid-line, letting the `^` anchor match a truncated fragment as a false owner; aligned the window start to a line boundary (per CodeRabbit review).

Both detection fixes target the general pattern, not just these field names.

## New high-level methods
Exposed the two new data-connector endpoints in `EnhancedDataConnectorsApi` (parity with the low-level client and the Python SDK):
- `dataConnectors.getSourceMetadata(connectorId, url)` → `GET /data-connectors/:id/source-metadata`. **Currently Grain-only**; other connector types return 501 (Not Implemented).
- `dataConnectors.syncFile(connectorId, url)` → `POST /data-connectors/:id/sync` (idempotent). Connector-agnostic — works for any connector type; `source_metadata` on the resulting file is only populated for Grain.

## Test plan
- `npm run generate && npm run build` ✅ passes
- Verified live against a Grain connector: `list`, `listFiles` (grain `source_metadata` with nullable `meeting_type`/`calendar_event`), `getSourceMetadata`, and `syncFile` (materializes the recording into a Cloudglue file).
- Verified `syncFile` also works on a **Google Drive** connector (file materialized, `source_metadata: null`), and that `getSourceMetadata` returns 501 for non-Grain connectors as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field detection accuracy when processing schemas with nullable and nullish properties to prevent misidentification of nested members.

* **Chores**
  * Released version 0.7.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->