### PR TITLE
Add visibility support to shareable assets

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -154,6 +154,9 @@ const describes = await client.segmentations.listSegmentationDescribes(segmentat
 ## Shareable Assets
 
 ```typescript
-// Create public sharing links via client.shareable
+// Create sharing links via client.shareable
+// visibility defaults to 'public' (viewable by anyone with the link);
+// pass visibility: 'private' for account-restricted, token-gated playback.
+// A file (or segment) can have at most one active share per visibility.
 // See source: src/api/shareable.api.ts
 ```

--- a/generated/Share.ts
+++ b/generated/Share.ts
@@ -8,6 +8,7 @@ type ShareableAsset = {
   title?: string | undefined;
   description?: string | undefined;
   metadata?: {} | undefined;
+  visibility?: ('public' | 'private') | undefined;
   preview_url?: string | undefined;
   media_download_url?: string | undefined;
   media_download_expires_at?: (number | null) | undefined;
@@ -34,6 +35,7 @@ const ShareableAsset: z.ZodType<ShareableAsset> = z
     title: z.string().optional(),
     description: z.string().optional(),
     metadata: z.object({}).partial().strict().passthrough().optional(),
+    visibility: z.enum(['public', 'private']).optional(),
     preview_url: z.string().optional(),
     media_download_url: z.string().optional(),
     media_download_expires_at: z.number().nullish(),
@@ -63,6 +65,7 @@ const CreateShareableAssetRequest = z
     title: z.string().optional(),
     description: z.string().optional(),
     metadata: z.object({}).partial().strict().passthrough().optional(),
+    visibility: z.enum(['public', 'private']).optional(),
   })
   .strict()
   .passthrough();
@@ -88,7 +91,7 @@ const endpoints = makeApi([
     method: 'post',
     path: '/share',
     alias: 'createShareableAsset',
-    description: `Create a publicly available shareable asset`,
+    description: `Create a shareable asset. Public assets (the default) are viewable by anyone with the link; private assets are restricted to members of the owning account and stream via a signed, token-gated playback url. A file (or file segment) can have at most one active share per visibility — one public and one private — each with its own stable URL; creating a second of the same visibility returns 409.`,
     requestFormat: 'json',
     parameters: [
       {
@@ -158,6 +161,11 @@ const endpoints = makeApi([
         name: 'created_after',
         type: 'Query',
         schema: z.string().optional(),
+      },
+      {
+        name: 'visibility',
+        type: 'Query',
+        schema: z.enum(['public', 'private']).optional(),
       },
     ],
     response: ShareableAssetListResponse,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/shareable.api.ts
+++ b/src/api/shareable.api.ts
@@ -10,6 +10,7 @@ export class EnhancedShareableApi {
     createdAfter?: string;
     fileId?: string;
     fileSegmentId?: string;
+    visibility?: 'public' | 'private';
   }) {
     return this.api.listShareableAssets({ queries: data });
   }
@@ -20,6 +21,7 @@ export class EnhancedShareableApi {
     title?: string;
     description?: string;
     metadata?: Record<string, unknown>;
+    visibility?: 'public' | 'private';
   }) {
     return this.api.createShareableAsset(data);
   }
@@ -56,6 +58,7 @@ export class EnhancedShareableApi {
       offset?: number;
       createdBefore?: string;
       createdAfter?: string;
+      visibility?: 'public' | 'private';
     },
   ) {
     return this.api.listShareableAssets({
@@ -71,6 +74,7 @@ export class EnhancedShareableApi {
       offset?: number;
       createdBefore?: string;
       createdAfter?: string;
+      visibility?: 'public' | 'private';
     },
   ) {
     return this.api.listShareableAssets({


### PR DESCRIPTION
## Summary
Latest OpenAPI spec adds a `visibility` (`'public' | 'private'`) field to the shareable assets API. This forwards it through the hand-written wrapper so SDK callers can use it.

- **`createShareableAsset`** — accepts `visibility?` (defaults to `public`); pass `'private'` for account-restricted, token-gated playback.
- **`listShareableAssets` / `getFileShareableAsset` / `getFileSegmentShareableAsset`** — accept `visibility?` as a list filter.
- Regenerated `generated/Share.ts` from the spec bump; version bump to 0.7.12.
- Updated `docs/advanced.md` to document public vs private shares.

`updateShareableAsset` is intentionally unchanged — the spec keeps visibility immutable (a file has at most one public + one private share, each with a stable URL).

## Test plan
- `npm run build` passes (tsc typecheck clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced shareable asset functionality with optional visibility parameter enabling both public and private sharing options for files and segments.

* **Documentation**
  * Updated advanced documentation explaining shareable assets visibility behavior, default settings, private account-restricted sharing, and sharing link creation constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->