### PR TITLE
Grain source_metadata: spec bump to v0.7.4 + nullable field regen

### DIFF
--- a/generated/common.ts
+++ b/generated/common.ts
@@ -192,7 +192,7 @@ export type GrainSourceMetadata = {
     | null
     | undefined;
   participants?:
-    | Array<
+    | (Array<
         Partial<{
           id: string;
           name: string;
@@ -201,16 +201,17 @@ export type GrainSourceMetadata = {
           confirmed_attendee: boolean;
           hs_contact_id: string | null;
         }>
-      >
+      > | null)
     | undefined;
-  highlights?: Array<{}> | undefined;
+  highlights?: (Array<{}> | null) | undefined;
   ai_summary?:
     | Partial<{
         text: string;
       }>
+    | null
     | undefined;
   ai_action_items?:
-    | Array<
+    | (Array<
         Partial<{
           status: 'pending' | 'completed';
           timestamp_ms: number;
@@ -221,9 +222,9 @@ export type GrainSourceMetadata = {
             user_id: string | null;
           }> | null;
         }>
-      >
+      > | null)
     | undefined;
-  ai_template_sections?: Array<{}> | undefined;
+  ai_template_sections?: (Array<{}> | null) | undefined;
   calendar_event?:
     | Partial<{
         ical_uid: string;
@@ -235,6 +236,7 @@ export type GrainSourceMetadata = {
         hubspot_company_ids: Array<string>;
         hubspot_deal_ids: Array<string>;
       }>
+    | null
     | undefined;
 };
 export type Describe = {
@@ -565,16 +567,16 @@ export const GrainSourceMetadata = z
           .strict()
           .passthrough()
       )
-      .optional(),
+      .nullish(),
     highlights: z
       .array(z.object({}).partial().strict().passthrough())
-      .optional(),
+      .nullish(),
     ai_summary: z
       .object({ text: z.string() })
       .partial()
       .strict()
       .passthrough()
-      .optional(),
+      .nullish(),
     ai_action_items: z
       .array(
         z
@@ -597,10 +599,10 @@ export const GrainSourceMetadata = z
           .strict()
           .passthrough()
       )
-      .optional(),
+      .nullish(),
     ai_template_sections: z
       .array(z.object({}).partial().strict().passthrough())
-      .optional(),
+      .nullish(),
     calendar_event: z
       .object({ ical_uid: z.string() })
       .partial()
@@ -615,7 +617,7 @@ export const GrainSourceMetadata = z
       .partial()
       .strict()
       .passthrough()
-      .optional(),
+      .nullish(),
   })
   .strict()
   .passthrough();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Summary

- Bumps the `cloudglue-api-spec` submodule to **v0.7.4** ([api-spec #98](https://github.com/cloudglue/cloudglue-api-spec/pull/98)), which marks the include-gated Grain `source_metadata` fields as nullable.
- Regenerates the client. The only generated change is in `GrainSourceMetadata` (`generated/common.ts`): `participants`, `highlights`, `ai_summary`, `ai_action_items`, `ai_template_sections`, and `calendar_event` move from `.optional()` → `.nullish()`, with matching `| null` TS types produced by the existing `generate.js` nullish/nullable transforms.
- Bumps SDK version `0.7.12` → `0.7.13`.

## Verification

- `npm run generate` is reproducible — re-running yields byte-identical output (only `common.ts` changes).
- `npm run build` (tsc) passes.
- Ran `getSourceMetadata()` against a live Grain connector: fetch + Zod parse both succeed with the new nullable schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.7.13
  * Submodule reference updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->