### PR TITLE
Add client-side URL normalization and url-only connector sync

### DIFF
--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -69,6 +69,7 @@ The sync methods normalize URLs client-side (see the `normalizeVideoUrl` utility
 - `https://drive.google.com/file/d/<id>/view`, `/open?id=<id>`, `/uc?id=<id>` → `gdrive://file/<id>`
 - `https://<bucket>.s3.<region>.amazonaws.com/<key>` (and path-style) → `s3://<bucket>/<key>`
 - `https://storage.googleapis.com/<bucket>/<key>` → `gs://<bucket>/<key>`
+- `https://www.dropbox.com/preview/<path>` and `/home/<folder>?preview=<file>` → `dropbox:///<path>` (these carry the real file path, unlike `scl/fi` share links)
 
 URLs that cannot map to any connector type — generic http(s) video URLs, YouTube, TikTok, Loom, and `www.dropbox.com` share links — are rejected client-side with guidance: they cannot be synced through a connector. Use them with general ingestion methods instead (`collections.addMediaByUrl()`, `describe.createDescribe()`, ...); see [Other Sources](./other-sources.md).
 

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -70,6 +70,7 @@ The sync methods normalize URLs client-side (see the `normalizeVideoUrl` utility
 - `https://<bucket>.s3.<region>.amazonaws.com/<key>` (and path-style) → `s3://<bucket>/<key>`
 - `https://storage.googleapis.com/<bucket>/<key>` → `gs://<bucket>/<key>`
 - `https://www.dropbox.com/preview/<path>` and `/home/<folder>?preview=<file>` → `dropbox:///<path>` (these carry the real file path, unlike `scl/fi` share links)
+- `https://grain.com/share/recording/<id>/<token>` → `grain://recording/<id>` (works when the recording is accessible to the connected Grain workspace; the token itself grants web-only access)
 
 URLs that cannot map to any connector type — generic http(s) video URLs, YouTube, TikTok, Loom, and `www.dropbox.com` share links — are rejected client-side with guidance: they cannot be synced through a connector. Use them with general ingestion methods instead (`collections.addMediaByUrl()`, `describe.createDescribe()`, ...); see [Other Sources](./other-sources.md).
 

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -1,6 +1,6 @@
 # Data Connectors API
 
-Browse files available in connected external data sources. Data connectors are configured in the Cloudglue dashboard — this API lets you list connectors and browse their files.
+Browse files available in connected external data sources and sync them into Cloudglue files. Data connectors are configured in the Cloudglue dashboard — this API lets you list connectors, browse their files, and materialize individual files.
 
 ## Supported Connectors
 
@@ -10,6 +10,7 @@ S3, Google Cloud Storage (GCS), Dropbox, Google Drive, Zoom, Gong, Recall, Grain
 
 ```typescript
 const connectors = await client.dataConnectors.list();
+// connectors.data: [{ id, type, created_at, ... }]
 ```
 
 ## Browse Files
@@ -31,4 +32,53 @@ const files = await client.dataConnectors.listFiles(connectorId, {
 });
 ```
 
-Files returned include URIs compatible with Cloudglue's import system — use them with `client.collections.addMediaByUrl()` or `client.describe.createDescribe()`.
+Each returned file has a `uri` (null for folders). These URIs are the canonical input for syncing — pass them verbatim to `syncFile()`/`syncUrl()`, or to general ingestion methods like `client.collections.addMediaByUrl()` or `client.describe.createDescribe()`.
+
+## Sync a File
+
+Materialize a connector URI into a Cloudglue file without starting a downstream job. Idempotent: syncing the same URI returns the existing file.
+
+```typescript
+// With an explicit connector:
+const file = await client.dataConnectors.syncFile(connectorId, 'gdrive://file/<fileId>');
+
+// Or let the SDK resolve the connector from the URL: picks the account's
+// oldest connector whose type matches the URL's source.
+const file = await client.dataConnectors.syncUrl('gdrive://file/<fileId>');
+```
+
+### Sync URI grammar
+
+Each connector type accepts URIs in the form emitted by `listFiles()`:
+
+| Connector type | URI form |
+|---|---|
+| `s3` | `s3://<bucket>/<key>` |
+| `gcs` | `gs://<bucket>/<key>` |
+| `google-drive` | `gdrive://file/<fileId>` |
+| `dropbox` | `dropbox://<path>` |
+| `zoom` | `zoom://uuid/<meetingUuid>`, `zoom://id/<meetingId>`, or `https://*.zoom.us/{j\|s\|recording/detail}/...` links |
+| `grain` | `grain://recording/<recordingId>` |
+| `gong` | `gong://call/<callId>` |
+| `recall` | `recall://recording/<recordingId>` |
+
+### Share links the SDK rewrites for you
+
+The sync methods normalize URLs client-side (see the `normalizeVideoUrl` utility in [Other Sources](./other-sources.md)), so these pasted links also work:
+
+- `https://drive.google.com/file/d/<id>/view`, `/open?id=<id>`, `/uc?id=<id>` → `gdrive://file/<id>`
+- `https://<bucket>.s3.<region>.amazonaws.com/<key>` (and path-style) → `s3://<bucket>/<key>`
+- `https://storage.googleapis.com/<bucket>/<key>` → `gs://<bucket>/<key>`
+
+URLs that cannot map to any connector type — generic http(s) video URLs, YouTube, TikTok, Loom, and `www.dropbox.com` share links — are rejected client-side with guidance: they cannot be synced through a connector. Use them with general ingestion methods instead (`collections.addMediaByUrl()`, `describe.createDescribe()`, ...); see [Other Sources](./other-sources.md).
+
+## Get Source Metadata
+
+Fetch metadata for a connector URI from the upstream source without creating a Cloudglue file. Currently supported for Grain; other connector types return 501.
+
+```typescript
+const metadata = await client.dataConnectors.getSourceMetadata(
+  connectorId,
+  'grain://recording/<recordingId>',
+);
+```

--- a/docs/other-sources.md
+++ b/docs/other-sources.md
@@ -1,10 +1,21 @@
 # Other Sources
 
-Use any publicly available video URL directly with Cloudglue. Accepted by most API endpoints that operate on a video.
+Use any publicly available video URL directly with Cloudglue. Accepted by most API endpoints that operate on a video (`collections.addMediaByUrl()`, `describe.createDescribe()`, `extract.createExtract()`, `segments.createSegmentJob()`, ...).
 
 ## Supported URLs
 
-Video URLs that point to a video file, as well as public YouTube, TikTok, and Loom URLs. 
+| Source | Accepted forms | Notes |
+|---|---|---|
+| Direct video/audio URLs | Any public `http(s)://` URL pointing at a media file | Validated server-side via content type (mp4, mov, webm, mkv, avi, ogg + common audio formats). HTML pages fail with an unsupported-media-type error. |
+| YouTube | `youtube.com/watch?v=`, `youtu.be/<id>`, `/shorts/`, `/live/`, `/embed/`, `/v/` | Public videos only. Shot-based segmentation is unavailable (no direct file access). |
+| TikTok | `tiktok.com/@user/video/<id>`, `tiktok.com/t/<code>`, `vm.tiktok.com/<code>`, `vt.tiktok.com/<code>` | Public videos only. |
+| Loom | `https://www.loom.com/share/<32-char-id>` | Public videos only. The SDK normalizes `loom.com/share/...` (no `www.`) and `/embed/` links to this form. |
+| Zoom | `https://*.zoom.us/j/...`, `/s/...`, `/recording/detail...` | `zoom.us/rec/share/...` and `/rec/play/...` recording links are **not** supported. |
+| Dropbox share links | `https://www.dropbox.com/scl/fi/...`, `/s/...` | Treated as a generic HTTP download (the server converts `dl=0` to `dl=1`): works only when the link is publicly accessible without login. Not usable with `dataConnectors.syncFile()`/`syncUrl()` — use the `dropbox://` URI from `dataConnectors.listFiles()` for connector sync. |
+| Connector URIs | `s3://`, `gs://`, `gdrive://file/`, `zoom://`, `grain://recording/`, ... | Require a matching data connector; see [Data Connectors](./data-connectors.md). |
+| Cloudglue files | `cloudglue://files/<fileId>` | References an already-ingested file. |
+
+Google Drive share links (`drive.google.com/file/d/<id>`), S3 object URLs, and GCS object URLs are not accepted by the API as-is, but the SDK rewrites them to their connector URI forms automatically (see below) — they work wherever a matching data connector exists.
 
 ## Using URLs with Cloudglue
 
@@ -18,3 +29,24 @@ const description = await client.describe.createDescribe(url, {
   enable_visual_scene_description: true,
 });
 ```
+
+## URL Utilities
+
+The SDK exports the URL helpers it uses internally for sync, so you can classify and normalize URLs yourself (e.g. to validate user input before making a request):
+
+```typescript
+import { classifyVideoUrl, normalizeVideoUrl } from '@cloudglue/cloudglue-js';
+
+classifyVideoUrl('https://youtu.be/dQw4w9WgXcQ');
+// 'youtube'
+
+const result = normalizeVideoUrl('https://drive.google.com/file/d/1a2bC3dE4f/view');
+// {
+//   url: 'gdrive://file/1a2bC3dE4f',   // form the API accepts
+//   source: 'google-drive',
+//   rewritten: true,
+//   warnings: [],                       // notes on known limitations, if any
+// }
+```
+
+`normalizeVideoUrl` rewrites Google Drive share links, S3/GCS https object URLs, and non-canonical Loom links; everything else passes through unchanged. `warnings` flags URL forms with known limitations (e.g. Dropbox share links, Zoom `/rec/` links). The data connector sync methods apply this normalization automatically.

--- a/docs/other-sources.md
+++ b/docs/other-sources.md
@@ -49,4 +49,4 @@ const result = normalizeVideoUrl('https://drive.google.com/file/d/1a2bC3dE4f/vie
 // }
 ```
 
-`normalizeVideoUrl` rewrites Google Drive share links, S3/GCS https object URLs, and non-canonical Loom links; everything else passes through unchanged. `warnings` flags URL forms with known limitations (e.g. Dropbox share links, Zoom `/rec/` links). The data connector sync methods apply this normalization automatically.
+`normalizeVideoUrl` rewrites Google Drive share links, S3/GCS https object URLs, Dropbox preview links (`/preview/<path>`, `/home/<folder>?preview=<file>` — these carry the real file path), and non-canonical Loom links; everything else passes through unchanged. `warnings` flags URL forms with known limitations (e.g. Dropbox share links, Zoom `/rec/` links). The data connector sync methods apply this normalization automatically.

--- a/docs/other-sources.md
+++ b/docs/other-sources.md
@@ -49,4 +49,4 @@ const result = normalizeVideoUrl('https://drive.google.com/file/d/1a2bC3dE4f/vie
 // }
 ```
 
-`normalizeVideoUrl` rewrites Google Drive share links, S3/GCS https object URLs, Dropbox preview links (`/preview/<path>`, `/home/<folder>?preview=<file>` — these carry the real file path), and non-canonical Loom links; everything else passes through unchanged. `warnings` flags URL forms with known limitations (e.g. Dropbox share links, Zoom `/rec/` links). The data connector sync methods apply this normalization automatically.
+`normalizeVideoUrl` rewrites Google Drive share links, S3/GCS https object URLs, Dropbox preview links (`/preview/<path>`, `/home/<folder>?preview=<file>` — these carry the real file path), Grain share links (`grain.com/share/recording/<id>/...` — syncs when the recording is in the connected Grain workspace), and non-canonical Loom links; everything else passes through unchanged. `warnings` flags URL forms with known limitations (e.g. Dropbox share links, Zoom `/rec/` links). The data connector sync methods apply this normalization automatically.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -30,6 +30,8 @@ Internally, the SDK uses:
 - **Axios** for HTTP transport (file uploads use axios directly for multipart/form-data)
 - Server-side validation only (`validate: false`)
 
+The SDK also exports standalone URL helpers (`classifyVideoUrl`, `normalizeVideoUrl`) that classify video URLs and rewrite common share links (Google Drive, S3, GCS, Loom) into API-accepted forms — see [Other Sources](./other-sources.md).
+
 ## API Namespace Reference
 
 | Namespace | Purpose | Key Methods |
@@ -47,7 +49,7 @@ Internally, the SDK uses:
 | `client.frames` | Frame extraction | Frame management |
 | `client.faceDetection` | Detect faces in video | `createFaceDetection`, `waitForReady` |
 | `client.faceMatch` | Match faces across videos | `createFaceMatch`, `waitForReady` |
-| `client.dataConnectors` | Browse connected data sources | `list`, `listFiles` |
+| `client.dataConnectors` | Browse & sync connected data sources | `list`, `listFiles`, `syncFile`, `syncUrl`, `getSourceMetadata` |
 | `client.webhooks` | Event notifications | CRUD operations |
 | `client.tags` | Video tagging | CRUD operations |
 | `client.shareable` | Public sharing links | CRUD operations |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "clean": "rimraf dist",
     "generate": "node generate.js",
     "build": "tsc && node scripts/build.js",
+    "test": "tsx --test test/*.test.ts",
     "watch": "tsc --watch",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/data-connectors.api.ts
+++ b/src/api/data-connectors.api.ts
@@ -1,4 +1,13 @@
 import { Data_ConnectorsApi } from '../../generated';
+import { CloudglueError } from '../error';
+import {
+  CONNECTOR_SYNC_URI_GRAMMAR,
+  NormalizedVideoUrl,
+  normalizeVideoUrl,
+} from '../url-utils';
+
+/** URL sources that can be synced through a data connector */
+const CONNECTOR_SOURCES = new Set(Object.keys(CONNECTOR_SYNC_URI_GRAMMAR));
 
 export interface ListDataConnectorFilesParams {
   /** Maximum number of files to return (1-100) */
@@ -60,7 +69,7 @@ export class EnhancedDataConnectorsApi {
   async getSourceMetadata(connectorId: string, url: string) {
     return this.api.getDataConnectorSourceMetadata({
       params: { id: connectorId },
-      queries: { url },
+      queries: { url: normalizeVideoUrl(url).url },
     });
   }
 
@@ -70,14 +79,75 @@ export class EnhancedDataConnectorsApi {
    * same URI returns the existing file. For Grain, the file's `source_metadata`
    * is populated from the recording.
    *
+   * Known https share links are rewritten client-side into connector URIs
+   * (e.g. `drive.google.com/file/d/<id>` → `gdrive://file/<id>`). URLs that
+   * cannot map to any connector type are rejected before the request is sent.
+   *
    * @param connectorId - The ID of the data connector
    * @param url - Connector URI to sync (must match the connector's type)
    * @returns The resulting Cloudglue file
    */
   async syncFile(connectorId: string, url: string) {
+    const normalized = this.normalizeForSync(url);
     return this.api.syncDataConnectorFile(
-      { url },
+      { url: normalized.url },
       { params: { id: connectorId } },
     );
+  }
+
+  /**
+   * Sync a URL without specifying a connector. The URL is normalized and
+   * classified client-side (known https share links are rewritten, e.g.
+   * `drive.google.com/file/d/<id>` → `gdrive://file/<id>`), then synced
+   * through the account's oldest data connector of the matching type.
+   *
+   * @param url - Connector URI or rewritable share link to sync
+   * @returns The resulting Cloudglue file
+   * @throws {CloudglueError} If the URL cannot map to a connector type, or no
+   *   connector of the matching type exists on the account
+   */
+  async syncUrl(url: string) {
+    const normalized = this.normalizeForSync(url);
+    const connectors = await this.list();
+    const matching = connectors.data.filter(
+      (connector) => connector.type === normalized.source,
+    );
+    if (matching.length === 0) {
+      throw new CloudglueError(
+        `No '${normalized.source}' data connector found on this account for URL '${url}'. Connect one, or use dataConnectors.syncFile(connectorId, url) with an explicit connector.`,
+        404,
+      );
+    }
+    const oldest = matching.reduce((a, b) =>
+      b.created_at < a.created_at ? b : a,
+    );
+    return this.api.syncDataConnectorFile(
+      { url: normalized.url },
+      { params: { id: oldest.id } },
+    );
+  }
+
+  /**
+   * Normalize a URL for the sync endpoint, rejecting URLs that cannot map to
+   * any connector type before a request is sent.
+   */
+  private normalizeForSync(url: string): NormalizedVideoUrl {
+    const normalized = normalizeVideoUrl(url);
+    if (!normalized.source || !CONNECTOR_SOURCES.has(normalized.source)) {
+      const grammar = Object.entries(CONNECTOR_SYNC_URI_GRAMMAR)
+        .map(([type, form]) => `  ${type}: ${form}`)
+        .join('\n');
+      throw new CloudglueError(
+        `URL '${url}' cannot be synced through a data connector` +
+          (normalized.source ? ` (classified as '${normalized.source}')` : '') +
+          '. Use the URI returned by dataConnectors.listFiles(), or one of these forms per connector type:\n' +
+          grammar +
+          (normalized.warnings.length
+            ? '\n' + normalized.warnings.join('\n')
+            : ''),
+        400,
+      );
+    }
+    return normalized;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,9 @@ export * from '../generated';
 export type * from './types';
 
 export * from './enums';
+
+/**
+ * URL classification and normalization utilities mirroring the API's
+ * server-side URL handling
+ */
+export * from './url-utils';

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -196,6 +196,20 @@ function rewriteDropboxPreviewUrl(parsed: URL): string | null {
   return null;
 }
 
+function rewriteGrainShareUrl(parsed: URL): string | null {
+  if (parsed.hostname !== 'grain.com' && parsed.hostname !== 'www.grain.com')
+    return null;
+  // Share links embed the recording id: grain.com/share/recording/<id>/<token>.
+  // The token only grants anonymous web access; the API resolves the id via
+  // the connected workspace, so this works when the recording is accessible
+  // to the connected Grain account.
+  const match = parsed.pathname.match(
+    /^\/share\/recording\/([a-zA-Z0-9_-]+)/,
+  );
+  if (match) return `grain://recording/${match[1]}`;
+  return null;
+}
+
 function rewriteLoomUrl(url: string, parsed: URL): string | null {
   // Already in the exact form the API accepts — leave untouched
   if (LOOM_SHARE_URL_REGEX.test(url)) return null;
@@ -251,6 +265,8 @@ function collectWarnings(url: string, warnings: string[]): void {
  *   → `gs://<bucket>/<key>`
  * - Dropbox preview links (`dropbox.com/preview/<path>`,
  *   `dropbox.com/home/<folder>?preview=<file>`) → `dropbox:///<path>`
+ * - Grain share links (`grain.com/share/recording/<id>/<token>`)
+ *   → `grain://recording/<id>`
  * - Loom links missing `www.` or using `/embed/` → canonical
  *   `https://www.loom.com/share/<id>`
  *
@@ -267,6 +283,7 @@ export function normalizeVideoUrl(url: string): NormalizedVideoUrl {
       rewriteS3Url(parsed) ??
       rewriteGcsUrl(parsed) ??
       rewriteDropboxPreviewUrl(parsed) ??
+      rewriteGrainShareUrl(parsed) ??
       rewriteLoomUrl(url, parsed);
     if (rewrittenUrl) result = rewrittenUrl;
   }

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -73,6 +73,16 @@ function tryParseUrl(url: string): URL | null {
   }
 }
 
+// Returns null on malformed percent-sequences (e.g. '%zz') so rewrites can
+// bail out and pass the URL through instead of throwing URIError
+function tryDecodeURIComponent(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Classify a URL the way the Cloudglue API will. Returns null when the input
  * is not an http(s) URL or a recognized URI scheme.
@@ -111,7 +121,7 @@ function rewriteGoogleDriveUrl(parsed: URL): string | null {
   if (parsed.hostname !== 'drive.google.com') return null;
   const fileMatch = parsed.pathname.match(/^\/file\/d\/([a-zA-Z0-9_-]+)/);
   if (fileMatch) return `gdrive://file/${fileMatch[1]}`;
-  if (parsed.pathname === '/open' || parsed.pathname === '/uc') {
+  if (/^\/(open|uc)\/?$/.test(parsed.pathname)) {
     const id = parsed.searchParams.get('id');
     if (id && /^[a-zA-Z0-9_-]+$/.test(id)) return `gdrive://file/${id}`;
   }
@@ -128,12 +138,13 @@ function rewriteS3Url(parsed: URL): string | null {
   // Path style: s3.amazonaws.com/<bucket>/<key>, s3.<region>.amazonaws.com/<bucket>/<key>
   const pathStyle = host.match(/^s3(?:[.-][a-z0-9-]+)*\.amazonaws\.com$/);
   if (virtualHosted) {
-    const key = decodeURIComponent(parsed.pathname.replace(/^\//, ''));
+    const key = tryDecodeURIComponent(parsed.pathname.replace(/^\//, ''));
     if (!key) return null;
     return `s3://${virtualHosted[1]}/${key}`;
   }
   if (pathStyle) {
-    const path = decodeURIComponent(parsed.pathname.replace(/^\//, ''));
+    const path = tryDecodeURIComponent(parsed.pathname.replace(/^\//, ''));
+    if (path === null) return null;
     const slashIdx = path.indexOf('/');
     if (slashIdx === -1 || slashIdx === path.length - 1) return null;
     return `s3://${path}`;
@@ -144,14 +155,15 @@ function rewriteS3Url(parsed: URL): string | null {
 function rewriteGcsUrl(parsed: URL): string | null {
   const host = parsed.hostname;
   if (host === 'storage.googleapis.com' || host === 'storage.cloud.google.com') {
-    const path = decodeURIComponent(parsed.pathname.replace(/^\//, ''));
+    const path = tryDecodeURIComponent(parsed.pathname.replace(/^\//, ''));
+    if (path === null) return null;
     const slashIdx = path.indexOf('/');
     if (slashIdx === -1 || slashIdx === path.length - 1) return null;
     return `gs://${path}`;
   }
   const virtualHosted = host.match(/^(.+)\.storage\.googleapis\.com$/);
   if (virtualHosted) {
-    const key = decodeURIComponent(parsed.pathname.replace(/^\//, ''));
+    const key = tryDecodeURIComponent(parsed.pathname.replace(/^\//, ''));
     if (!key) return null;
     return `gs://${virtualHosted[1]}/${key}`;
   }
@@ -169,14 +181,15 @@ function rewriteDropboxPreviewUrl(parsed: URL): string | null {
   //   /preview/<path>?...            → dropbox:///<path>
   //   /home/<folder>?preview=<file>  → dropbox:///<folder>/<file>
   if (parsed.pathname.startsWith('/preview/')) {
-    const path = decodeURIComponent(parsed.pathname.slice('/preview'.length));
-    if (path.length <= 1) return null;
+    const path = tryDecodeURIComponent(parsed.pathname.slice('/preview'.length));
+    if (path === null || path.length <= 1) return null;
     return `dropbox://${path}`;
   }
   if (parsed.pathname === '/home' || parsed.pathname.startsWith('/home/')) {
     const file = parsed.searchParams.get('preview');
     if (!file) return null;
-    const folder = decodeURIComponent(parsed.pathname.slice('/home'.length));
+    const folder = tryDecodeURIComponent(parsed.pathname.slice('/home'.length));
+    if (folder === null) return null;
     return `dropbox://${folder}/${file}`;
   }
   return null;

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -158,6 +158,30 @@ function rewriteGcsUrl(parsed: URL): string | null {
   return null;
 }
 
+function rewriteDropboxPreviewUrl(parsed: URL): string | null {
+  if (
+    parsed.hostname !== 'www.dropbox.com' &&
+    parsed.hostname !== 'dropbox.com'
+  )
+    return null;
+  // Unlike scl/fi share links, preview links carry the real file path, so
+  // they can be rewritten to the dropbox:// URI form that listFiles emits:
+  //   /preview/<path>?...            → dropbox:///<path>
+  //   /home/<folder>?preview=<file>  → dropbox:///<folder>/<file>
+  if (parsed.pathname.startsWith('/preview/')) {
+    const path = decodeURIComponent(parsed.pathname.slice('/preview'.length));
+    if (path.length <= 1) return null;
+    return `dropbox://${path}`;
+  }
+  if (parsed.pathname === '/home' || parsed.pathname.startsWith('/home/')) {
+    const file = parsed.searchParams.get('preview');
+    if (!file) return null;
+    const folder = decodeURIComponent(parsed.pathname.slice('/home'.length));
+    return `dropbox://${folder}/${file}`;
+  }
+  return null;
+}
+
 function rewriteLoomUrl(url: string, parsed: URL): string | null {
   // Already in the exact form the API accepts — leave untouched
   if (LOOM_SHARE_URL_REGEX.test(url)) return null;
@@ -211,6 +235,8 @@ function collectWarnings(url: string, warnings: string[]): void {
  * - S3 object URLs (virtual-hosted or path style) → `s3://<bucket>/<key>`
  * - GCS object URLs (`storage.googleapis.com`, `storage.cloud.google.com`)
  *   → `gs://<bucket>/<key>`
+ * - Dropbox preview links (`dropbox.com/preview/<path>`,
+ *   `dropbox.com/home/<folder>?preview=<file>`) → `dropbox:///<path>`
  * - Loom links missing `www.` or using `/embed/` → canonical
  *   `https://www.loom.com/share/<id>`
  *
@@ -226,6 +252,7 @@ export function normalizeVideoUrl(url: string): NormalizedVideoUrl {
       rewriteGoogleDriveUrl(parsed) ??
       rewriteS3Url(parsed) ??
       rewriteGcsUrl(parsed) ??
+      rewriteDropboxPreviewUrl(parsed) ??
       rewriteLoomUrl(url, parsed);
     if (rewrittenUrl) result = rewrittenUrl;
   }

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -1,0 +1,234 @@
+/**
+ * Client-side URL classification and normalization utilities.
+ *
+ * These mirror the Cloudglue API's server-side URL handling so the SDK can
+ * rewrite the links users actually paste (e.g. Google Drive share links,
+ * https S3/GCS object URLs) into the URI forms the API accepts, before any
+ * network call is made. URL-accepting SDK methods apply `normalizeVideoUrl`
+ * automatically; both functions are also exported for direct use.
+ */
+
+/**
+ * How the Cloudglue API classifies a URL. `video` is a `cloudglue://files/`
+ * URI referencing an existing Cloudglue file; `http` is the generic fallback
+ * for any other http(s) URL.
+ */
+export type VideoUrlSource =
+  | 'youtube'
+  | 's3'
+  | 'dropbox'
+  | 'video'
+  | 'zoom'
+  | 'google-drive'
+  | 'tiktok'
+  | 'loom'
+  | 'http'
+  | 'gong'
+  | 'recall'
+  | 'gcs'
+  | 'grain';
+
+export interface NormalizedVideoUrl {
+  /** The URL to send to the API (rewritten when a known share-link form was recognized) */
+  url: string;
+  /** How the API will classify the (possibly rewritten) URL, or null if not a recognizable URL */
+  source: VideoUrlSource | null;
+  /** True when the URL was rewritten into a different form */
+  rewritten: boolean;
+  /** Human-readable notes about known limitations of the given URL form */
+  warnings: string[];
+}
+
+// These regexes intentionally match the API server's classification rules.
+const YOUTUBE_VIDEO_REGEX =
+  /^https?:\/\/(?:www\.)?(?:youtube\.com\/(?:watch\?(?:[^&]*&)*v=|embed\/|v\/|shorts\/|live\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
+const ZOOM_HTTPS_REGEX =
+  /^https:\/\/([a-z0-9-]+\.)?zoom\.us\/(j\/|s\/|recording\/detail)/i;
+const TIKTOK_URL_REGEX =
+  /^https?:\/\/(?:(?:www\.)?tiktok\.com\/(?:t\/|@[^/]+\/video\/)|(?:vm|vt)\.tiktok\.com\/)/i;
+const LOOM_SHARE_URL_REGEX =
+  /^https:\/\/www\.loom\.com\/share\/([a-zA-Z0-9_-]{32})/;
+
+/**
+ * Connector URI grammar accepted by `POST /data-connectors/:id/sync`, keyed
+ * by connector type. URIs returned by `dataConnectors.listFiles()` already
+ * use these forms.
+ */
+export const CONNECTOR_SYNC_URI_GRAMMAR: Record<string, string> = {
+  s3: 's3://<bucket>/<key>',
+  gcs: 'gs://<bucket>/<key>',
+  'google-drive': 'gdrive://file/<fileId>',
+  dropbox: 'dropbox://<path>',
+  zoom: 'zoom://uuid/<meetingUuid>, zoom://id/<meetingId>, or https://*.zoom.us/{j|s|recording/detail}/... links',
+  grain: 'grain://recording/<recordingId>',
+  gong: 'gong://call/<callId>',
+  recall: 'recall://recording/<recordingId>',
+};
+
+function tryParseUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Classify a URL the way the Cloudglue API will. Returns null when the input
+ * is not an http(s) URL or a recognized URI scheme.
+ */
+export function classifyVideoUrl(url: string): VideoUrlSource | null {
+  if (YOUTUBE_VIDEO_REGEX.test(url)) return 'youtube';
+  if (url.startsWith('s3://')) return 's3';
+  if (url.startsWith('dropbox://') || url.includes('dl.dropboxusercontent.com'))
+    return 'dropbox';
+  if (url.startsWith('cloudglue://files')) return 'video';
+  if (
+    url.startsWith('zoom://uuid/') ||
+    url.startsWith('zoom://id/') ||
+    ZOOM_HTTPS_REGEX.test(url)
+  )
+    return 'zoom';
+  if (url.startsWith('gdrive://file/')) return 'google-drive';
+  if (TIKTOK_URL_REGEX.test(url)) return 'tiktok';
+  if (LOOM_SHARE_URL_REGEX.test(url)) return 'loom';
+  if (url.startsWith('gong://call/')) return 'gong';
+  if (url.startsWith('recall://recording/')) return 'recall';
+  if (url.startsWith('gs://')) return 'gcs';
+  if (url.startsWith('grain://recording/')) return 'grain';
+  const parsed = tryParseUrl(url);
+  if (parsed && (parsed.protocol === 'http:' || parsed.protocol === 'https:'))
+    return 'http';
+  return null;
+}
+
+function rewriteGoogleDriveUrl(parsed: URL): string | null {
+  if (parsed.hostname !== 'drive.google.com') return null;
+  const fileMatch = parsed.pathname.match(/^\/file\/d\/([a-zA-Z0-9_-]+)/);
+  if (fileMatch) return `gdrive://file/${fileMatch[1]}`;
+  if (parsed.pathname === '/open' || parsed.pathname === '/uc') {
+    const id = parsed.searchParams.get('id');
+    if (id && /^[a-zA-Z0-9_-]+$/.test(id)) return `gdrive://file/${id}`;
+  }
+  return null;
+}
+
+function rewriteS3Url(parsed: URL): string | null {
+  const host = parsed.hostname;
+  // Virtual-hosted style: <bucket>.s3.amazonaws.com, <bucket>.s3.<region>.amazonaws.com,
+  // <bucket>.s3-<region>.amazonaws.com (legacy), incl. dualstack variants
+  const virtualHosted = host.match(
+    /^(.+?)\.s3(?:[.-][a-z0-9-]+)*\.amazonaws\.com$/,
+  );
+  // Path style: s3.amazonaws.com/<bucket>/<key>, s3.<region>.amazonaws.com/<bucket>/<key>
+  const pathStyle = host.match(/^s3(?:[.-][a-z0-9-]+)*\.amazonaws\.com$/);
+  if (virtualHosted) {
+    const key = decodeURIComponent(parsed.pathname.replace(/^\//, ''));
+    if (!key) return null;
+    return `s3://${virtualHosted[1]}/${key}`;
+  }
+  if (pathStyle) {
+    const path = decodeURIComponent(parsed.pathname.replace(/^\//, ''));
+    const slashIdx = path.indexOf('/');
+    if (slashIdx === -1 || slashIdx === path.length - 1) return null;
+    return `s3://${path}`;
+  }
+  return null;
+}
+
+function rewriteGcsUrl(parsed: URL): string | null {
+  const host = parsed.hostname;
+  if (host === 'storage.googleapis.com' || host === 'storage.cloud.google.com') {
+    const path = decodeURIComponent(parsed.pathname.replace(/^\//, ''));
+    const slashIdx = path.indexOf('/');
+    if (slashIdx === -1 || slashIdx === path.length - 1) return null;
+    return `gs://${path}`;
+  }
+  const virtualHosted = host.match(/^(.+)\.storage\.googleapis\.com$/);
+  if (virtualHosted) {
+    const key = decodeURIComponent(parsed.pathname.replace(/^\//, ''));
+    if (!key) return null;
+    return `gs://${virtualHosted[1]}/${key}`;
+  }
+  return null;
+}
+
+function rewriteLoomUrl(url: string, parsed: URL): string | null {
+  // Already in the exact form the API accepts — leave untouched
+  if (LOOM_SHARE_URL_REGEX.test(url)) return null;
+  if (parsed.hostname !== 'loom.com' && parsed.hostname !== 'www.loom.com')
+    return null;
+  const match = parsed.pathname.match(
+    /^\/(?:share|embed)\/([a-zA-Z0-9_-]{32})/,
+  );
+  if (match) return `https://www.loom.com/share/${match[1]}`;
+  return null;
+}
+
+function collectWarnings(url: string, warnings: string[]): void {
+  const parsed = tryParseUrl(url);
+  if (!parsed) return;
+  const host = parsed.hostname;
+  if (host === 'www.dropbox.com' || host === 'dropbox.com') {
+    if (
+      parsed.pathname.startsWith('/scl/fi/') ||
+      parsed.pathname.startsWith('/s/')
+    ) {
+      warnings.push(
+        'Dropbox share links are treated as generic HTTP downloads: they work with general ingestion methods (e.g. collections.addMediaByUrl) only when the link is publicly accessible, and cannot be used with dataConnectors.syncFile(). To sync via a Dropbox connector, use the dropbox:// URI returned by dataConnectors.listFiles().',
+      );
+    }
+  }
+  if (
+    host === 'dl.dropboxusercontent.com' &&
+    !parsed.pathname.startsWith('/1/view/')
+  ) {
+    warnings.push(
+      'Only dl.dropboxusercontent.com/1/view/... URLs are accepted for Dropbox sync; other dl.dropboxusercontent.com forms (e.g. /scl/fi/...) may be rejected.',
+    );
+  }
+  if (
+    (host === 'zoom.us' || host.endsWith('.zoom.us')) &&
+    parsed.pathname.startsWith('/rec/')
+  ) {
+    warnings.push(
+      'Zoom recording share links (zoom.us/rec/...) are not supported. Use a zoom://uuid/<meetingUuid> URI from dataConnectors.listFiles(), or a https://*.zoom.us/{j|s|recording/detail} link.',
+    );
+  }
+}
+
+/**
+ * Normalize a video URL into the form the Cloudglue API accepts.
+ *
+ * Rewrites, when recognized:
+ * - Google Drive share links (`drive.google.com/file/d/<id>`, `/open?id=`,
+ *   `/uc?id=`) → `gdrive://file/<id>`
+ * - S3 object URLs (virtual-hosted or path style) → `s3://<bucket>/<key>`
+ * - GCS object URLs (`storage.googleapis.com`, `storage.cloud.google.com`)
+ *   → `gs://<bucket>/<key>`
+ * - Loom links missing `www.` or using `/embed/` → canonical
+ *   `https://www.loom.com/share/<id>`
+ *
+ * Everything else passes through unchanged. `warnings` flags URL forms with
+ * known limitations (e.g. Dropbox share links, Zoom `/rec/` links).
+ */
+export function normalizeVideoUrl(url: string): NormalizedVideoUrl {
+  const warnings: string[] = [];
+  let result = url;
+  const parsed = tryParseUrl(url);
+  if (parsed && (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
+    const rewrittenUrl =
+      rewriteGoogleDriveUrl(parsed) ??
+      rewriteS3Url(parsed) ??
+      rewriteGcsUrl(parsed) ??
+      rewriteLoomUrl(url, parsed);
+    if (rewrittenUrl) result = rewrittenUrl;
+  }
+  collectWarnings(result, warnings);
+  return {
+    url: result,
+    source: classifyVideoUrl(result),
+    rewritten: result !== url,
+    warnings,
+  };
+}

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -190,7 +190,8 @@ function rewriteDropboxPreviewUrl(parsed: URL): string | null {
     if (!file) return null;
     const folder = tryDecodeURIComponent(parsed.pathname.slice('/home'.length));
     if (folder === null) return null;
-    return `dropbox://${folder}/${file}`;
+    // Trailing slash ('/home/', '/home/folder/') would otherwise double up
+    return `dropbox://${folder.replace(/\/+$/, '')}/${file}`;
   }
   return null;
 }

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -80,7 +80,12 @@ function tryParseUrl(url: string): URL | null {
 export function classifyVideoUrl(url: string): VideoUrlSource | null {
   if (YOUTUBE_VIDEO_REGEX.test(url)) return 'youtube';
   if (url.startsWith('s3://')) return 's3';
-  if (url.startsWith('dropbox://') || url.includes('dl.dropboxusercontent.com'))
+  // The server matches dl.dropboxusercontent.com as a substring; match on the
+  // hostname instead so unrelated URLs embedding that string classify as http
+  if (
+    url.startsWith('dropbox://') ||
+    tryParseUrl(url)?.hostname === 'dl.dropboxusercontent.com'
+  )
     return 'dropbox';
   if (url.startsWith('cloudglue://files')) return 'video';
   if (

--- a/test/data-connectors.test.ts
+++ b/test/data-connectors.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { EnhancedDataConnectorsApi } from '../src/api/data-connectors.api';
+import { CloudglueError } from '../src/error';
+
+function makeApi(connectors: Array<{ id: string; type: string; created_at: number }>) {
+  const calls: Array<{ url: string; connectorId: string }> = [];
+  const api = {
+    listDataConnectors: async () => ({ object: 'list', data: connectors }),
+    syncDataConnectorFile: async (
+      body: { url: string },
+      config: { params: { id: string } },
+    ) => {
+      calls.push({ url: body.url, connectorId: config.params.id });
+      return { id: 'file_1' };
+    },
+  };
+  return { api: api as any, calls };
+}
+
+describe('dataConnectors.syncUrl', () => {
+  it('routes to the oldest connector of the matching type', async () => {
+    const { api, calls } = makeApi([
+      { id: 'gdrive_new', type: 'google-drive', created_at: 2000 },
+      { id: 'gdrive_old', type: 'google-drive', created_at: 1000 },
+      { id: 'dropbox_1', type: 'dropbox', created_at: 500 },
+    ]);
+    const client = new EnhancedDataConnectorsApi(api);
+
+    await client.syncUrl('gdrive://file/abc123');
+
+    assert.deepEqual(calls, [
+      { url: 'gdrive://file/abc123', connectorId: 'gdrive_old' },
+    ]);
+  });
+
+  it('rewrites share links before resolving the connector', async () => {
+    const { api, calls } = makeApi([
+      { id: 'gdrive_1', type: 'google-drive', created_at: 1000 },
+    ]);
+    const client = new EnhancedDataConnectorsApi(api);
+
+    await client.syncUrl('https://drive.google.com/file/d/abc123/view?usp=sharing');
+
+    assert.deepEqual(calls, [
+      { url: 'gdrive://file/abc123', connectorId: 'gdrive_1' },
+    ]);
+  });
+
+  it('rejects URLs with no matching connector on the account', async () => {
+    const { api } = makeApi([
+      { id: 'dropbox_1', type: 'dropbox', created_at: 500 },
+    ]);
+    const client = new EnhancedDataConnectorsApi(api);
+
+    await assert.rejects(
+      client.syncUrl('s3://bucket/key.mp4'),
+      (err: unknown) =>
+        err instanceof CloudglueError && /No 's3' data connector/.test(err.message),
+    );
+  });
+
+  it('rejects non-connector URLs client-side without a request', async () => {
+    const { api, calls } = makeApi([
+      { id: 'dropbox_1', type: 'dropbox', created_at: 500 },
+    ]);
+    const client = new EnhancedDataConnectorsApi(api);
+
+    for (const url of [
+      'https://example.com/video.mp4',
+      'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      'https://www.dropbox.com/scl/fi/abc/video.mp4?dl=0',
+    ]) {
+      await assert.rejects(
+        client.syncUrl(url),
+        (err: unknown) =>
+          err instanceof CloudglueError &&
+          /cannot be synced through a data connector/.test(err.message),
+      );
+    }
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe('dataConnectors.syncFile', () => {
+  it('normalizes the url and uses the given connector', async () => {
+    const { api, calls } = makeApi([]);
+    const client = new EnhancedDataConnectorsApi(api);
+
+    await client.syncFile(
+      'conn_1',
+      'https://my-bucket.s3.us-west-2.amazonaws.com/folder/video.mp4',
+    );
+
+    assert.deepEqual(calls, [
+      { url: 's3://my-bucket/folder/video.mp4', connectorId: 'conn_1' },
+    ]);
+  });
+
+  it('passes connector URIs through verbatim', async () => {
+    const { api, calls } = makeApi([]);
+    const client = new EnhancedDataConnectorsApi(api);
+
+    await client.syncFile('conn_1', 'dropbox:///test/video.mp4');
+
+    assert.deepEqual(calls, [
+      { url: 'dropbox:///test/video.mp4', connectorId: 'conn_1' },
+    ]);
+  });
+});

--- a/test/url-utils.test.ts
+++ b/test/url-utils.test.ts
@@ -162,6 +162,16 @@ describe('normalizeVideoUrl rewrites', () => {
       'dropbox:///video.mp4',
       'dropbox',
     ],
+    [
+      'https://www.dropbox.com/home/?preview=video.mp4',
+      'dropbox:///video.mp4',
+      'dropbox',
+    ],
+    [
+      'https://www.dropbox.com/home/test%20with%20spaces/?preview=runyourway.mp4',
+      'dropbox:///test with spaces/runyourway.mp4',
+      'dropbox',
+    ],
     // Loom variants → canonical share URL
     [
       'https://loom.com/share/0281766fa2d04bb788eaf19e65135184',

--- a/test/url-utils.test.ts
+++ b/test/url-utils.test.ts
@@ -1,0 +1,238 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyVideoUrl,
+  normalizeVideoUrl,
+  CONNECTOR_SYNC_URI_GRAMMAR,
+} from '../src/url-utils';
+
+describe('classifyVideoUrl', () => {
+  const cases: Array<[string, string | null]> = [
+    ['https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'youtube'],
+    ['https://youtu.be/dQw4w9WgXcQ', 'youtube'],
+    ['https://www.youtube.com/shorts/dQw4w9WgXcQ', 'youtube'],
+    ['https://www.youtube.com/live/dQw4w9WgXcQ', 'youtube'],
+    ['s3://my-bucket/folder/video.mp4', 's3'],
+    ['gs://my-bucket/folder/video.mp4', 'gcs'],
+    ['dropbox:///test/video.mp4', 'dropbox'],
+    ['https://dl.dropboxusercontent.com/1/view/abc/test/video.mp4', 'dropbox'],
+    ['cloudglue://files/123e4567-e89b-12d3-a456-426614174000', 'video'],
+    ['zoom://uuid/abc%3D%3D', 'zoom'],
+    ['zoom://id/123456789', 'zoom'],
+    ['https://us02web.zoom.us/j/123456789', 'zoom'],
+    ['https://zoom.us/recording/detail?meeting_id=abc', 'zoom'],
+    ['gdrive://file/1a2b3c4d5e', 'google-drive'],
+    ['https://www.tiktok.com/@user/video/7123456789012345678', 'tiktok'],
+    ['https://vm.tiktok.com/ZM8abcdef/', 'tiktok'],
+    ['https://vt.tiktok.com/ZM8abcdef/', 'tiktok'],
+    ['https://www.tiktok.com/t/ZM8abcdef/', 'tiktok'],
+    ['https://www.loom.com/share/0281766fa2d04bb788eaf19e65135184', 'loom'],
+    ['gong://call/123456', 'gong'],
+    ['recall://recording/abc-123', 'recall'],
+    ['grain://recording/abc-123', 'grain'],
+    ['https://example.com/video.mp4', 'http'],
+    ['http://example.com/video.mp4', 'http'],
+    // share links the server treats as generic http
+    [
+      'https://www.dropbox.com/scl/fi/r85h2r4d9s13la63r5pzf/video.mp4?rlkey=x&dl=0',
+      'http',
+    ],
+    ['https://zoom.us/rec/share/abcdef', 'http'],
+    // loom without www / http scheme falls through to http
+    ['https://loom.com/share/0281766fa2d04bb788eaf19e65135184', 'http'],
+    ['not a url', null],
+    ['ftp://example.com/video.mp4', null],
+  ];
+
+  for (const [url, expected] of cases) {
+    it(`classifies ${url} as ${expected}`, () => {
+      assert.equal(classifyVideoUrl(url), expected);
+    });
+  }
+});
+
+describe('normalizeVideoUrl rewrites', () => {
+  const rewriteCases: Array<[string, string, string]> = [
+    // Google Drive
+    [
+      'https://drive.google.com/file/d/1a2bC3dE4fG5hI6jK7lM/view?usp=sharing',
+      'gdrive://file/1a2bC3dE4fG5hI6jK7lM',
+      'google-drive',
+    ],
+    [
+      'https://drive.google.com/file/d/1a2bC3dE4fG5hI6jK7lM/preview',
+      'gdrive://file/1a2bC3dE4fG5hI6jK7lM',
+      'google-drive',
+    ],
+    [
+      'https://drive.google.com/open?id=1a2bC3dE4fG5hI6jK7lM',
+      'gdrive://file/1a2bC3dE4fG5hI6jK7lM',
+      'google-drive',
+    ],
+    [
+      'https://drive.google.com/uc?export=download&id=1a2bC3dE4fG5hI6jK7lM',
+      'gdrive://file/1a2bC3dE4fG5hI6jK7lM',
+      'google-drive',
+    ],
+    // S3 virtual-hosted style
+    [
+      'https://my-bucket.s3.amazonaws.com/folder/video.mp4',
+      's3://my-bucket/folder/video.mp4',
+      's3',
+    ],
+    [
+      'https://my-bucket.s3.us-west-2.amazonaws.com/folder/video.mp4',
+      's3://my-bucket/folder/video.mp4',
+      's3',
+    ],
+    [
+      'https://my-bucket.s3-eu-west-1.amazonaws.com/video.mp4',
+      's3://my-bucket/video.mp4',
+      's3',
+    ],
+    [
+      'https://my-bucket.s3.dualstack.us-east-1.amazonaws.com/video.mp4',
+      's3://my-bucket/video.mp4',
+      's3',
+    ],
+    // S3 path style
+    [
+      'https://s3.amazonaws.com/my-bucket/folder/video.mp4',
+      's3://my-bucket/folder/video.mp4',
+      's3',
+    ],
+    [
+      'https://s3.us-east-1.amazonaws.com/my-bucket/video.mp4',
+      's3://my-bucket/video.mp4',
+      's3',
+    ],
+    // S3 percent-encoded key
+    [
+      'https://my-bucket.s3.amazonaws.com/my%20folder/video%20file.mp4',
+      's3://my-bucket/my folder/video file.mp4',
+      's3',
+    ],
+    // GCS
+    [
+      'https://storage.googleapis.com/my-bucket/folder/video.mp4',
+      'gs://my-bucket/folder/video.mp4',
+      'gcs',
+    ],
+    [
+      'https://storage.cloud.google.com/my-bucket/video.mp4',
+      'gs://my-bucket/video.mp4',
+      'gcs',
+    ],
+    [
+      'https://my-bucket.storage.googleapis.com/folder/video.mp4',
+      'gs://my-bucket/folder/video.mp4',
+      'gcs',
+    ],
+    // Loom variants → canonical share URL
+    [
+      'https://loom.com/share/0281766fa2d04bb788eaf19e65135184',
+      'https://www.loom.com/share/0281766fa2d04bb788eaf19e65135184',
+      'loom',
+    ],
+    [
+      'https://www.loom.com/embed/0281766fa2d04bb788eaf19e65135184',
+      'https://www.loom.com/share/0281766fa2d04bb788eaf19e65135184',
+      'loom',
+    ],
+  ];
+
+  for (const [input, expectedUrl, expectedSource] of rewriteCases) {
+    it(`rewrites ${input} → ${expectedUrl}`, () => {
+      const result = normalizeVideoUrl(input);
+      assert.equal(result.url, expectedUrl);
+      assert.equal(result.source, expectedSource);
+      assert.equal(result.rewritten, true);
+    });
+  }
+});
+
+describe('normalizeVideoUrl pass-throughs', () => {
+  const passthroughCases: string[] = [
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    'https://www.tiktok.com/@user/video/7123456789012345678',
+    'https://vm.tiktok.com/ZM8abcdef/',
+    'https://www.loom.com/share/0281766fa2d04bb788eaf19e65135184?sid=x',
+    'https://us02web.zoom.us/j/123456789',
+    'https://example.com/video.mp4',
+    // dropbox URIs pass through verbatim — never rewritten client-side
+    'dropbox:///test/video.mp4',
+    'dropbox://test/video.mp4',
+    's3://my-bucket/video.mp4',
+    'gs://my-bucket/video.mp4',
+    'gdrive://file/abc',
+    'grain://recording/abc',
+    'cloudglue://files/123e4567-e89b-12d3-a456-426614174000',
+    'not a url',
+  ];
+
+  for (const url of passthroughCases) {
+    it(`passes through ${url}`, () => {
+      const result = normalizeVideoUrl(url);
+      assert.equal(result.url, url);
+      assert.equal(result.rewritten, false);
+    });
+  }
+});
+
+describe('normalizeVideoUrl warnings', () => {
+  it('warns on www.dropbox.com share links (scl/fi form)', () => {
+    const result = normalizeVideoUrl(
+      'https://www.dropbox.com/scl/fi/r85h2r4d9s13la63r5pzf/video.mp4?rlkey=x&dl=0',
+    );
+    assert.equal(result.source, 'http');
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /syncFile/);
+  });
+
+  it('warns on legacy /s/ dropbox share links', () => {
+    const result = normalizeVideoUrl(
+      'https://www.dropbox.com/s/abc123/video.mp4?dl=0',
+    );
+    assert.equal(result.warnings.length, 1);
+  });
+
+  it('warns on non-/1/view dl.dropboxusercontent.com URLs', () => {
+    const result = normalizeVideoUrl(
+      'https://dl.dropboxusercontent.com/scl/fi/r85h2r4d9s13la63r5pzf/video.mp4?rlkey=x',
+    );
+    assert.equal(result.source, 'dropbox');
+    assert.equal(result.warnings.length, 1);
+  });
+
+  it('does not warn on /1/view dl.dropboxusercontent.com URLs', () => {
+    const result = normalizeVideoUrl(
+      'https://dl.dropboxusercontent.com/1/view/abc/test/video.mp4',
+    );
+    assert.equal(result.source, 'dropbox');
+    assert.equal(result.warnings.length, 0);
+  });
+
+  it('warns on zoom.us/rec/ recording links', () => {
+    const result = normalizeVideoUrl('https://us02web.zoom.us/rec/share/abc');
+    assert.equal(result.source, 'http');
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /zoom/i);
+  });
+
+  it('produces no warnings for clean URLs', () => {
+    assert.equal(
+      normalizeVideoUrl('https://example.com/video.mp4').warnings.length,
+      0,
+    );
+  });
+});
+
+describe('CONNECTOR_SYNC_URI_GRAMMAR', () => {
+  it('covers all connector types', () => {
+    assert.deepEqual(
+      Object.keys(CONNECTOR_SYNC_URI_GRAMMAR).sort(),
+      ['dropbox', 'gcs', 'gong', 'google-drive', 'grain', 'recall', 's3', 'zoom'].sort(),
+    );
+  });
+});

--- a/test/url-utils.test.ts
+++ b/test/url-utils.test.ts
@@ -131,6 +131,27 @@ describe('normalizeVideoUrl rewrites', () => {
       'gs://my-bucket/folder/video.mp4',
       'gcs',
     ],
+    // Dropbox preview links → dropbox:/// URI (same form listFiles emits)
+    [
+      'https://www.dropbox.com/preview/test%20with%20spaces/runyourway.mp4?context=content_suggestions&role=personal',
+      'dropbox:///test with spaces/runyourway.mp4',
+      'dropbox',
+    ],
+    [
+      'https://www.dropbox.com/preview/root-video.mp4',
+      'dropbox:///root-video.mp4',
+      'dropbox',
+    ],
+    [
+      'https://www.dropbox.com/home/test%20with%20spaces?preview=runyourway.mp4',
+      'dropbox:///test with spaces/runyourway.mp4',
+      'dropbox',
+    ],
+    [
+      'https://www.dropbox.com/home?preview=video.mp4',
+      'dropbox:///video.mp4',
+      'dropbox',
+    ],
     // Loom variants → canonical share URL
     [
       'https://loom.com/share/0281766fa2d04bb788eaf19e65135184',
@@ -162,6 +183,8 @@ describe('normalizeVideoUrl pass-throughs', () => {
     'https://www.loom.com/share/0281766fa2d04bb788eaf19e65135184?sid=x',
     'https://us02web.zoom.us/j/123456789',
     'https://example.com/video.mp4',
+    // dropbox /home without a preview file has nothing to rewrite to
+    'https://www.dropbox.com/home/test%20with%20spaces',
     // dropbox URIs pass through verbatim — never rewritten client-side
     'dropbox:///test/video.mp4',
     'dropbox://test/video.mp4',

--- a/test/url-utils.test.ts
+++ b/test/url-utils.test.ts
@@ -41,6 +41,8 @@ describe('classifyVideoUrl', () => {
     ['https://zoom.us/rec/share/abcdef', 'http'],
     // loom without www / http scheme falls through to http
     ['https://loom.com/share/0281766fa2d04bb788eaf19e65135184', 'http'],
+    // hostname must actually be dl.dropboxusercontent.com, not a substring elsewhere
+    ['https://evil.com/dl.dropboxusercontent.com/video.mp4', 'http'],
     ['not a url', null],
     ['ftp://example.com/video.mp4', null],
   ];

--- a/test/url-utils.test.ts
+++ b/test/url-utils.test.ts
@@ -77,6 +77,16 @@ describe('normalizeVideoUrl rewrites', () => {
       'gdrive://file/1a2bC3dE4fG5hI6jK7lM',
       'google-drive',
     ],
+    [
+      'https://drive.google.com/open/?id=1a2bC3dE4fG5hI6jK7lM',
+      'gdrive://file/1a2bC3dE4fG5hI6jK7lM',
+      'google-drive',
+    ],
+    [
+      'https://drive.google.com/uc/?id=1a2bC3dE4fG5hI6jK7lM',
+      'gdrive://file/1a2bC3dE4fG5hI6jK7lM',
+      'google-drive',
+    ],
     // S3 virtual-hosted style
     [
       'https://my-bucket.s3.amazonaws.com/folder/video.mp4',
@@ -185,6 +195,10 @@ describe('normalizeVideoUrl pass-throughs', () => {
     'https://example.com/video.mp4',
     // dropbox /home without a preview file has nothing to rewrite to
     'https://www.dropbox.com/home/test%20with%20spaces',
+    // malformed percent-encoding must pass through, not throw URIError
+    'https://my-bucket.s3.amazonaws.com/bad%zzkey.mp4',
+    'https://storage.googleapis.com/my-bucket/bad%zzkey.mp4',
+    'https://www.dropbox.com/preview/bad%zzpath/video.mp4',
     // dropbox URIs pass through verbatim — never rewritten client-side
     'dropbox:///test/video.mp4',
     'dropbox://test/video.mp4',

--- a/test/url-utils.test.ts
+++ b/test/url-utils.test.ts
@@ -172,6 +172,17 @@ describe('normalizeVideoUrl rewrites', () => {
       'dropbox:///test with spaces/runyourway.mp4',
       'dropbox',
     ],
+    // Grain share links → grain://recording/<id> (token segment dropped)
+    [
+      'https://grain.com/share/recording/7109135c-36fa-4ac3-99c9-911ceeb59344/XpCfdKVKG7zVYHSW16KeVyh7EDUSGt9ELYGMntdl',
+      'grain://recording/7109135c-36fa-4ac3-99c9-911ceeb59344',
+      'grain',
+    ],
+    [
+      'https://grain.com/share/recording/7109135c-36fa-4ac3-99c9-911ceeb59344',
+      'grain://recording/7109135c-36fa-4ac3-99c9-911ceeb59344',
+      'grain',
+    ],
     // Loom variants → canonical share URL
     [
       'https://loom.com/share/0281766fa2d04bb788eaf19e65135184',
@@ -205,6 +216,8 @@ describe('normalizeVideoUrl pass-throughs', () => {
     'https://example.com/video.mp4',
     // dropbox /home without a preview file has nothing to rewrite to
     'https://www.dropbox.com/home/test%20with%20spaces',
+    // grain non-share pages are not recording references
+    'https://grain.com/app/meetings',
     // malformed percent-encoding must pass through, not throw URIError
     'https://my-bucket.s3.amazonaws.com/bad%zzkey.mp4',
     'https://storage.googleapis.com/my-bucket/bad%zzkey.mp4',


### PR DESCRIPTION
## Summary

Makes it easier to get videos from data connectors and pasted share links into Cloudglue, by handling URL normalization client-side in the SDK.

- **New `url-utils` module** (exported from the package root):
  - `classifyVideoUrl(url)` — classifies a URL the way the API does (youtube, dropbox, s3, gcs, google-drive, zoom, tiktok, loom, http, ...)
  - `normalizeVideoUrl(url)` — rewrites pasted share links into the URI forms the API accepts:
    - `drive.google.com/file/d/<id>`, `/open?id=`, `/uc?id=` → `gdrive://file/<id>`
    - S3 object URLs (virtual-hosted + path style) → `s3://<bucket>/<key>`
    - GCS object URLs → `gs://<bucket>/<key>`
    - non-canonical Loom links → `https://www.loom.com/share/<id>`
    - returns `warnings` for known-limited forms (www.dropbox.com share links, zoom.us/rec links)
- **`dataConnectors.syncUrl(url)`** — url-only sync: normalizes/classifies the URL, then syncs through the account's oldest connector of the matching type
- **`syncFile` / `getSourceMetadata`** now normalize URLs, and the sync methods reject URLs that can't map to any connector type client-side with an actionable error listing the per-connector URI grammar (instead of the server's opaque `URL source 'http' does not match connector type` error)
- Non-sync APIs (describe, extract, collections, ...) are intentionally untouched
- Docs: sync URI grammar + supported URL source tables in `docs/data-connectors.md`, `docs/other-sources.md`, `docs/overview.md`
- Tests: new `npm run test` (node:test via tsx, no new deps), 72 cases

## Notes

- `dropbox://` URIs pass through verbatim by design: connector-side Dropbox path sync is currently broken server-side (path-parsing off-by-one, reported separately), and the SDK avoids guessing the post-fix canonical form so list→sync round-trips start working as soon as the server fix lands.

## Test plan

- `npm run test` — 72/72 pass (url classification, every rewrite rule, pass-throughs, warnings, syncUrl connector resolution against a stubbed API)
- `npm run build` — clean compile; exports spot-checked on the built package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SDK exposes URL classification and normalization helpers for client-side URL handling
  * Added sync-by-URL: auto-detect connector type and sync files from URLs

* **Documentation**
  * Expanded Data Connectors API docs with sync workflows, supported-URL grammar, normalization behavior, and metadata examples
  * Added comprehensive guide on supported URLs and URL utilities usage

* **Tests**
  * Added unit tests for connector sync behaviors and URL utilities

* **Chores**
  * Package version bumped and project test script added
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public URL parsing and connector auto-selection could mis-route syncs if classification diverges from the API; scope is SDK client-side only with broad test coverage.
> 
> **Overview**
> Adds **client-side URL handling** and **connector sync ergonomics** in v0.7.14: new exported `classifyVideoUrl` / `normalizeVideoUrl` rewrite pasted share links (Google Drive, S3/GCS HTTPS, Dropbox preview, Grain share, Loom variants) into API-accepted connector URIs, with classification and limitation **warnings**.
> 
> **`dataConnectors`** now normalizes URLs on `syncFile`, `getSourceMetadata`, and the new **`syncUrl`** (picks the account’s oldest connector of the matching type). Non-connector URLs are rejected before HTTP with a per-connector URI grammar error instead of opaque server mismatches. General ingestion APIs are unchanged.
> 
> Docs expand data-connector sync workflows and supported URL tables; **`npm run test`** runs node:test coverage for URL utils and connector sync behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d15eeac6f0d14e2ac56d7991034d8ea1aa2344. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->