### PR TITLE
Add files.syncFromUrl + connector share-link support (API 0.7.5)

### DIFF
--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -56,11 +56,13 @@ Each connector type accepts URIs in the form emitted by `listFiles()`:
 | `s3` | `s3://<bucket>/<key>` |
 | `gcs` | `gs://<bucket>/<key>` |
 | `google-drive` | `gdrive://file/<fileId>` |
-| `dropbox` | `dropbox://<path>` |
-| `zoom` | `zoom://uuid/<meetingUuid>`, `zoom://id/<meetingId>`, or `https://*.zoom.us/{j\|s\|recording/detail}/...` links |
+| `dropbox` | `dropbox://<path>`, or `https://www.dropbox.com/{scl/fi\|s}/...` file share links |
+| `zoom` | `zoom://uuid/<meetingUuid>`, `zoom://id/<meetingId>`, or `https://*.zoom.us/{j\|s\|recording/detail\|rec/share}/...` links |
 | `grain` | `grain://recording/<recordingId>` |
 | `gong` | `gong://call/<callId>` |
 | `recall` | `recall://recording/<recordingId>` |
+
+`dropbox://` path parsing is tolerant: any leading-slash count and %-encoding spellings of the same path resolve — and dedupe — to the same file.
 
 ### Share links the SDK rewrites for you
 
@@ -69,10 +71,15 @@ The sync methods normalize URLs client-side (see the `normalizeVideoUrl` utility
 - `https://drive.google.com/file/d/<id>/view`, `/open?id=<id>`, `/uc?id=<id>` → `gdrive://file/<id>`
 - `https://<bucket>.s3.<region>.amazonaws.com/<key>` (and path-style) → `s3://<bucket>/<key>`
 - `https://storage.googleapis.com/<bucket>/<key>` → `gs://<bucket>/<key>`
-- `https://www.dropbox.com/preview/<path>` and `/home/<folder>?preview=<file>` → `dropbox:///<path>` (these carry the real file path, unlike `scl/fi` share links)
+- `https://www.dropbox.com/preview/<path>` and `/home/<folder>?preview=<file>` → `dropbox:///<path>` (these carry the real file path)
 - `https://grain.com/share/recording/<id>/<token>` → `grain://recording/<id>` (works when the recording is accessible to the connected Grain workspace; the token itself grants web-only access)
 
-URLs that cannot map to any connector type — generic http(s) video URLs, YouTube, TikTok, Loom, and `www.dropbox.com` share links — are rejected client-side with guidance: they cannot be synced through a connector. Use them with general ingestion methods instead (`collections.addMediaByUrl()`, `describe.createDescribe()`, ...); see [Other Sources](./other-sources.md).
+These share links pass through as-is and are resolved server-side via the connector's OAuth:
+
+- Dropbox file share links (`https://www.dropbox.com/scl/fi/...`, `/s/...`) — works for login-gated files. Folder share links (`/scl/fo/...`) are rejected with 400.
+- Zoom `https://*.zoom.us/rec/share/<token>` links — **best-effort**: Zoom often mints a new share token each time a link is copied from the portal, so fresh links may 404. The reliable form is the recording-detail link (`zoom.us/recording/detail?meeting_id=<uuid>`), which works for any recording age. `rec/play` links are rejected.
+
+URLs that cannot map to any connector type — generic http(s) video URLs, YouTube, TikTok, Loom — are rejected client-side with guidance: they cannot be synced through a connector. Ingest them without a connector via `files.syncFromUrl()` (YouTube: `collections.addMediaByUrl()` only), or use them directly with general ingestion methods (`collections.addMediaByUrl()`, `describe.createDescribe()`, ...); see [Other Sources](./other-sources.md).
 
 ## Get Source Metadata
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -30,6 +30,20 @@ try {
 | 429 | Rate limit exceeded | Back off and retry. Check your plan's rate limits. |
 | 500 | Server error | Retry with exponential backoff. |
 
+## URL Ingestion & Sync Errors
+
+On URL ingestion endpoints (`files.syncFromUrl()`, `dataConnectors.syncFile()`/`syncUrl()`, `collections.addMediaByUrl()`, ...):
+
+| Status | Cause | Fix |
+|--------|-------|-----|
+| 400 | Folder link (Dropbox `/scl/fo/...`, Drive folder), unsupported video-page host (`vimeo.com`, `1drv.ms`, `onedrive.live.com`, `box.com`), or URL/connector type mismatch | Share a single file; for unsupported hosts, use a direct-download URL shape (e.g. `app.box.com/shared/static/...`, `player.vimeo.com/progressive_redirect/...`). |
+| 402 | Insufficient credit balance (TikTok URLs consume scrape credits) | Top up credits or remove TikTok URLs. |
+| 403 | Source file not accessible (login-gated, expired, or restricted share link) | Make the link public, or sync via a data connector's OAuth (`dataConnectors.syncFile()`). |
+| 404 | File/recording not found at the source (e.g. a stale Zoom `rec/share` token) | For Zoom, use the recording-detail link (`zoom.us/recording/detail?meeting_id=<uuid>`). |
+| 415 | URL does not serve a supported video/audio content type | Point at the media file itself, not an HTML page. |
+| 429 | External service rate limit (Dropbox, Zoom) or plan resource limits (upload count, duration, file size) | Retry shortly; check plan limits. |
+| 502 | Upstream/network failure fetching the source | Retry with backoff. |
+
 ## Polling Timeouts
 
 `waitForReady()` methods throw `CloudglueError` when max attempts are reached:

--- a/docs/files.md
+++ b/docs/files.md
@@ -17,6 +17,31 @@ const file = await client.files.waitForReady(uploaded.data.id);
 
 **Note:** File uploads use `multipart/form-data` via axios directly (not Zodios). The `file` parameter must be a `globalThis.File` object.
 
+## Sync from URL
+
+Materialize a publicly accessible URL into a Cloudglue file without a data connector or a collection. Idempotent: syncing the same URL returns the existing file.
+
+```typescript
+const file = await client.files.syncFromUrl('https://example.com/video.mp4', {
+  metadata: { project: 'demo' },           // optional key-value metadata
+  enable_segment_thumbnails: true,          // optional, defaults to true (matching upload)
+});
+
+const ready = await client.files.waitForReady(file.id);
+```
+
+Accepted URL forms:
+
+- Direct http(s) video/audio file URLs (e.g. `.mp4`)
+- Public Dropbox share links (`dropbox.com/scl/fi/...`, `/s/...`)
+- TikTok video URLs (consumes scrape credits — 402 if the balance is insufficient)
+- Loom share URLs (non-canonical forms are rewritten client-side)
+
+Not accepted — the SDK rejects these client-side with guidance:
+
+- YouTube URLs: collection-only, use `collections.addMediaByUrl()`
+- Connector-native URLs (`s3://`, `gs://`, `gdrive://`, `dropbox://`, Zoom/Gong/Recall/Grain links, Drive share links): use `dataConnectors.syncFile()`/`syncUrl()` — see [Data Connectors](./data-connectors.md)
+
 ## List Files
 
 ```typescript

--- a/docs/other-sources.md
+++ b/docs/other-sources.md
@@ -1,6 +1,6 @@
 # Other Sources
 
-Use any publicly available video URL directly with Cloudglue. Accepted by most API endpoints that operate on a video (`collections.addMediaByUrl()`, `describe.createDescribe()`, `extract.createExtract()`, `segments.createSegmentJob()`, ...).
+Use any publicly available video URL directly with Cloudglue. Accepted by most API endpoints that operate on a video (`collections.addMediaByUrl()`, `describe.createDescribe()`, `extract.createExtract()`, `segments.createSegmentJob()`, ...). To materialize a URL into a standalone file without starting a job, use `files.syncFromUrl()` (see [Files](./files.md)).
 
 ## Supported URLs
 
@@ -10,12 +10,14 @@ Use any publicly available video URL directly with Cloudglue. Accepted by most A
 | YouTube | `youtube.com/watch?v=`, `youtu.be/<id>`, `/shorts/`, `/live/`, `/embed/`, `/v/` | Public videos only. Shot-based segmentation is unavailable (no direct file access). |
 | TikTok | `tiktok.com/@user/video/<id>`, `tiktok.com/t/<code>`, `vm.tiktok.com/<code>`, `vt.tiktok.com/<code>` | Public videos only. |
 | Loom | `https://www.loom.com/share/<32-char-id>` | Public videos only. The SDK normalizes `loom.com/share/...` (no `www.`) and `/embed/` links to this form. |
-| Zoom | `https://*.zoom.us/j/...`, `/s/...`, `/recording/detail...` | `zoom.us/rec/share/...` and `/rec/play/...` recording links are **not** supported. |
-| Dropbox share links | `https://www.dropbox.com/scl/fi/...`, `/s/...` | Treated as a generic HTTP download (the server converts `dl=0` to `dl=1`): works only when the link is publicly accessible without login. Not usable with `dataConnectors.syncFile()`/`syncUrl()` — use the `dropbox://` URI from `dataConnectors.listFiles()` for connector sync. |
+| Zoom | `https://*.zoom.us/j/...`, `/s/...`, `/recording/detail...`, `/rec/share/...` | Requires a Zoom data connector. `rec/share` links resolve **best-effort**: Zoom often mints a new share token each time a link is copied, so fresh links may 404 — the reliable form is the recording-detail link (`zoom.us/recording/detail?meeting_id=<uuid>`). `/rec/play/...` links are **not** supported. |
+| Dropbox file share links | `https://www.dropbox.com/scl/fi/...`, `/s/...` | Sync through a Dropbox data connector via OAuth (`dataConnectors.syncFile()`/`syncUrl()`), including login-gated links. Without a connector, they work on general ingestion (and `files.syncFromUrl()`) only when publicly accessible (the server converts `dl=0` to `dl=1`); login-gated/expired links fail with 403. Folder share links (`/scl/fo/...`) are rejected with 400. |
 | Connector URIs | `s3://`, `gs://`, `gdrive://file/`, `zoom://`, `grain://recording/`, ... | Require a matching data connector; see [Data Connectors](./data-connectors.md). |
 | Cloudglue files | `cloudglue://files/<fileId>` | References an already-ingested file. |
 
-Google Drive share links (`drive.google.com/file/d/<id>`), S3 object URLs, and GCS object URLs are not accepted by the API as-is, but the SDK rewrites them to their connector URI forms automatically (see below) — they work wherever a matching data connector exists.
+Google Drive share links (`drive.google.com/file/d/<id>`, `/open?id=<id>`) are normalized server-side to `gdrive://file/<id>` and work wherever a Google Drive connector exists; `uc?id=` direct-download links stay on the anonymous http path. S3 and GCS object URLs are rewritten client-side to their connector URI forms (see below).
+
+**Unsupported video-page hosts:** page links from `vimeo.com`, `1drv.ms`, `onedrive.live.com`, and `box.com` are rejected with a specific 400. Direct-download shapes from those services still work as generic http URLs (e.g. `app.box.com/shared/static/...`, `player.vimeo.com/progressive_redirect/...`).
 
 ## Using URLs with Cloudglue
 
@@ -49,4 +51,4 @@ const result = normalizeVideoUrl('https://drive.google.com/file/d/1a2bC3dE4f/vie
 // }
 ```
 
-`normalizeVideoUrl` rewrites Google Drive share links, S3/GCS https object URLs, Dropbox preview links (`/preview/<path>`, `/home/<folder>?preview=<file>` — these carry the real file path), Grain share links (`grain.com/share/recording/<id>/...` — syncs when the recording is in the connected Grain workspace), and non-canonical Loom links; everything else passes through unchanged. `warnings` flags URL forms with known limitations (e.g. Dropbox share links, Zoom `/rec/` links). The data connector sync methods apply this normalization automatically.
+`normalizeVideoUrl` rewrites Google Drive share links, S3/GCS https object URLs, Dropbox preview links (`/preview/<path>`, `/home/<folder>?preview=<file>` — these carry the real file path), Grain share links (`grain.com/share/recording/<id>/...` — syncs when the recording is in the connected Grain workspace), and non-canonical Loom links; everything else passes through unchanged. `warnings` flags URL forms with known limitations (e.g. Dropbox folder links, Zoom `/rec/play/` links, best-effort Zoom `/rec/share/` tokens). The data connector sync methods and `files.syncFromUrl()` apply this normalization automatically.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -36,7 +36,7 @@ The SDK also exports standalone URL helpers (`classifyVideoUrl`, `normalizeVideo
 
 | Namespace | Purpose | Key Methods |
 |-----------|---------|-------------|
-| `client.files` | Upload & manage video files | `uploadFile`, `listFiles`, `getFile`, `deleteFile`, `waitForReady` |
+| `client.files` | Upload & manage video files | `uploadFile`, `syncFromUrl`, `listFiles`, `getFile`, `deleteFile`, `waitForReady` |
 | `client.collections` | Organize videos into groups | `createCollection`, `addMedia`, `listVideos`, `waitForReady` |
 | `client.describe` | Multimodal video descriptions | `createDescribe`, `getDescribe`, `waitForReady` |
 | `client.extract` | Structured data extraction | `createExtract`, `getExtract`, `waitForReady` |

--- a/generated/Data_Connectors.ts
+++ b/generated/Data_Connectors.ts
@@ -241,7 +241,7 @@ const endpoints = makeApi([
     method: 'post',
     path: '/data-connectors/:id/sync',
     alias: 'syncDataConnectorFile',
-    description: `Materialize a connector URI (e.g. &#x60;grain://recording/&lt;id&gt;&#x60;) into a Cloudglue file without starting a downstream job. Idempotent: syncing the same URI returns the existing file. For Grain, the file&#x27;s &#x60;source_metadata&#x60; is populated from the recording.`,
+    description: `Materialize a connector URI (e.g. &#x60;grain://recording/&lt;id&gt;&#x60;) into a Cloudglue file without starting a downstream job. Idempotent: syncing the same URI returns the existing file. For Grain, the file&#x27;s &#x60;source_metadata&#x60; is populated from the recording. Plain http(s), TikTok, and Loom URLs are not connector-syncable; ingest those via POST /files/sync instead. YouTube URLs can only be added to a collection via the add-media endpoint.`,
     requestFormat: 'json',
     parameters: [
       {
@@ -259,12 +259,22 @@ const endpoints = makeApi([
     errors: [
       {
         status: 400,
-        description: `Bad request (e.g. URL source does not match the connector type)`,
+        description: `Bad request (e.g. URL source does not match the connector type, or the link points to a folder)`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 403,
+        description: `The source file is not accessible (e.g. a login-gated, expired, or restricted Dropbox share link)`,
         schema: z.object({ error: z.string() }).strict().passthrough(),
       },
       {
         status: 404,
-        description: `Data connector not found`,
+        description: `Data connector not found, or the referenced file/recording was not found at the source`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 429,
+        description: `The external service rate-limited the request (e.g. Dropbox or Zoom); retry shortly`,
         schema: z.object({ error: z.string() }).strict().passthrough(),
       },
       {

--- a/generated/Files.ts
+++ b/generated/Files.ts
@@ -278,6 +278,14 @@ const FileUpload = z
   })
   .strict()
   .passthrough();
+const syncFileFromUrl_Body = z
+  .object({
+    url: z.string(),
+    metadata: z.object({}).partial().strict().passthrough().optional(),
+    enable_segment_thumbnails: z.boolean().optional(),
+  })
+  .strict()
+  .passthrough();
 const FileDelete = z
   .object({ id: z.string(), object: z.literal('file') })
   .strict()
@@ -308,6 +316,7 @@ export const schemas = {
   FileSegment,
   FileSegmentListResponse,
   FileUpload,
+  syncFileFromUrl_Body,
   FileDelete,
   FileUpdate,
   createFileSegmentation_Body,
@@ -411,6 +420,58 @@ const endpoints = makeApi([
     ],
     response: FileList,
     errors: [
+      {
+        status: 500,
+        description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'post',
+    path: '/files/sync',
+    alias: 'syncFileFromUrl',
+    description: `Materialize a publicly accessible URL into a Cloudglue file without a data connector or a collection. Accepts direct http(s) video/audio file URLs (e.g. &#x60;.mp4&#x60;), public Dropbox share links, TikTok video URLs, and Loom share URLs. Idempotent: syncing the same URL returns the existing file. YouTube URLs are not supported here — add them to a collection via the add-media endpoint instead. Connector-native URIs (e.g. &#x60;s3://&#x60;, &#x60;gs://&#x60;, &#x60;gdrive://&#x60;, Zoom/Gong/Recall/Grain links) require the matching data connector — use POST /data-connectors/{id}/sync.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'body',
+        type: 'Body',
+        schema: syncFileFromUrl_Body,
+      },
+    ],
+    response: CloudglueFile,
+    errors: [
+      {
+        status: 400,
+        description: `Bad request (e.g. an unsupported URL such as YouTube or a connector-native URI, a page link from an unsupported host, a file exceeding size or duration limits, or a URL that does not serve a media file)`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 402,
+        description: `Insufficient credit balance (TikTok URLs consume scrape credits)`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 403,
+        description: `The source file is not accessible (e.g. a login-gated, expired, or restricted share link)`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 404,
+        description: `The URL was not found or not accessible`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 415,
+        description: `The URL does not serve a supported video or audio content type`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 429,
+        description: `Resource limits exceeded (monthly upload limit, total duration, file size, or total files)`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
       {
         status: 500,
         description: `An unexpected error occurred on the server`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.14",
+      "version": "0.7.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/data-connectors.api.ts
+++ b/src/api/data-connectors.api.ts
@@ -50,7 +50,10 @@ export class EnhancedDataConnectorsApi {
    * @param params - Optional filtering and pagination parameters
    * @returns Paginated list of files in the data source
    */
-  async listFiles(connectorId: string, params: ListDataConnectorFilesParams = {}) {
+  async listFiles(
+    connectorId: string,
+    params: ListDataConnectorFilesParams = {},
+  ) {
     return this.api.listDataConnectorFiles({
       params: { id: connectorId },
       queries: params,
@@ -80,8 +83,13 @@ export class EnhancedDataConnectorsApi {
    * is populated from the recording.
    *
    * Known https share links are rewritten client-side into connector URIs
-   * (e.g. `drive.google.com/file/d/<id>` → `gdrive://file/<id>`). URLs that
-   * cannot map to any connector type are rejected before the request is sent.
+   * (e.g. `drive.google.com/file/d/<id>` → `gdrive://file/<id>`), and some
+   * pass through for server-side resolution via the connector's OAuth:
+   * Dropbox file share links (`dropbox.com/scl/fi/...`, `/s/...` — works for
+   * login-gated files) and Zoom `rec/share` links (best-effort: Zoom often
+   * mints a new share token per copy; `zoom.us/recording/detail?meeting_id=`
+   * links are the reliable form). URLs that cannot map to any connector type
+   * are rejected before the request is sent.
    *
    * @param connectorId - The ID of the data connector
    * @param url - Connector URI to sync (must match the connector's type)
@@ -137,11 +145,17 @@ export class EnhancedDataConnectorsApi {
       const grammar = Object.entries(CONNECTOR_SYNC_URI_GRAMMAR)
         .map(([type, form]) => `  ${type}: ${form}`)
         .join('\n');
+      const hint =
+        normalized.source === 'youtube'
+          ? 'YouTube URLs can only be added to a collection — use collections.addMediaByUrl().'
+          : 'Publicly accessible URLs (direct media URLs, public Dropbox share links, TikTok, Loom) can be synced into a file without a connector via files.syncFromUrl().';
       throw new CloudglueError(
         `URL '${url}' cannot be synced through a data connector` +
           (normalized.source ? ` (classified as '${normalized.source}')` : '') +
           '. Use the URI returned by dataConnectors.listFiles(), or one of these forms per connector type:\n' +
           grammar +
+          '\n' +
+          hint +
           (normalized.warnings.length
             ? '\n' + normalized.warnings.join('\n')
             : ''),

--- a/src/api/files.api.ts
+++ b/src/api/files.api.ts
@@ -8,7 +8,7 @@ import {
   WaitForReadyOptions,
 } from '../types';
 import { CloudglueError } from '../error';
-import { normalizeVideoUrl } from '../url-utils';
+import { isDropboxFileShareLink, normalizeVideoUrl } from '../url-utils';
 
 import type { AxiosResponse } from 'axios';
 
@@ -33,9 +33,10 @@ type SyncFromUrlParams = {
 
 /**
  * URL sources `POST /files/sync` resolves through a data connector instead of
- * fetching anonymously. `dropbox` is absent: https Dropbox share links are
- * accepted here (when public), while `dropbox://` URIs are caught by the
- * connector-URI check.
+ * fetching anonymously. `dropbox` is absent because it splits by URL form:
+ * https file share links are accepted here (when public), while `dropbox://`
+ * URIs and `dl.dropboxusercontent.com` URLs are connector-only — see the
+ * dropbox-specific check in the guard.
  */
 const CONNECTOR_ONLY_SOURCES = new Set([
   's3',
@@ -167,7 +168,9 @@ export class EnhancedFilesApi {
     if (!driveUc) {
       if (
         !isHttpUrl(normalized.url) ||
-        CONNECTOR_ONLY_SOURCES.has(normalized.source)
+        CONNECTOR_ONLY_SOURCES.has(normalized.source) ||
+        (normalized.source === 'dropbox' &&
+          !isDropboxFileShareLink(normalized.url))
       ) {
         throw new CloudglueError(
           `URL '${url}' resolves through a data connector ('${normalized.source}') and cannot be synced anonymously. Use dataConnectors.syncFile(connectorId, url) or dataConnectors.syncUrl(url) instead.` +

--- a/src/api/files.api.ts
+++ b/src/api/files.api.ts
@@ -8,6 +8,7 @@ import {
   WaitForReadyOptions,
 } from '../types';
 import { CloudglueError } from '../error';
+import { normalizeVideoUrl } from '../url-utils';
 
 import type { AxiosResponse } from 'axios';
 
@@ -19,6 +20,46 @@ type UploadFileParams = {
    */
   enable_segment_thumbnails?: boolean;
 };
+
+type SyncFromUrlParams = {
+  /** Key-value metadata to attach to the created file */
+  metadata?: Record<string, any>;
+  /**
+   * Whether to generate per-segment thumbnails for the file. Defaults to
+   * true server-side, matching file upload.
+   */
+  enable_segment_thumbnails?: boolean;
+};
+
+/**
+ * URL sources `POST /files/sync` resolves through a data connector instead of
+ * fetching anonymously. `dropbox` is absent: https Dropbox share links are
+ * accepted here (when public), while `dropbox://` URIs are caught by the
+ * connector-URI check.
+ */
+const CONNECTOR_ONLY_SOURCES = new Set([
+  's3',
+  'gcs',
+  'google-drive',
+  'zoom',
+  'gong',
+  'recall',
+  'grain',
+]);
+
+const isHttpUrl = (url: string) => /^https?:\/\//i.test(url);
+
+function isDriveUcLink(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname === 'drive.google.com' &&
+      /^\/uc\/?$/.test(parsed.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
 
 export class EnhancedFilesApi {
   constructor(private readonly api: typeof FilesApi) {}
@@ -78,6 +119,78 @@ export class EnhancedFilesApi {
         'Content-Type': 'multipart/form-data',
       },
     });
+  }
+
+  /**
+   * Materialize a publicly accessible URL into a Cloudglue file without a
+   * data connector or a collection. Accepts direct http(s) video/audio file
+   * URLs (e.g. `.mp4`), public Dropbox share links, TikTok video URLs, and
+   * Loom share URLs. Idempotent: syncing the same URL returns the existing
+   * file. The returned file may still be processing — chain
+   * `files.waitForReady(file.id)` to wait for it.
+   *
+   * Non-canonical Loom links are rewritten client-side to the form the API
+   * accepts. URLs the API cannot ingest here are rejected before the request
+   * is sent: YouTube URLs (collection-only — use
+   * `collections.addMediaByUrl()`) and connector-native URLs (`s3://`,
+   * `gs://`, `gdrive://`, Zoom/Grain links, ... — use
+   * `dataConnectors.syncFile()`/`syncUrl()`).
+   *
+   * @param url - Publicly accessible URL to sync
+   * @param params - Optional metadata and thumbnail settings
+   * @returns The resulting Cloudglue file
+   * @throws {CloudglueError} If the URL is not ingestible by this endpoint
+   */
+  async syncFromUrl(url: string, params: SyncFromUrlParams = {}) {
+    const normalized = normalizeVideoUrl(url);
+
+    if (!normalized.source) {
+      throw new CloudglueError(`'${url}' is not a valid http(s) URL.`, 400);
+    }
+    if (normalized.source === 'youtube') {
+      throw new CloudglueError(
+        `YouTube URLs cannot be synced into a standalone file. Add the video to a collection with collections.addMediaByUrl() instead.`,
+        400,
+      );
+    }
+    if (normalized.source === 'video') {
+      throw new CloudglueError(
+        `'${url}' already references a Cloudglue file — use files.getFile() with its file ID instead.`,
+        400,
+      );
+    }
+
+    // Google Drive `uc?id=` links rewrite to gdrive:// for connector sync,
+    // but the server keeps them on the anonymous http path here — send the
+    // original URL and skip the connector checks.
+    const driveUc = isDriveUcLink(url);
+    if (!driveUc) {
+      if (
+        !isHttpUrl(normalized.url) ||
+        CONNECTOR_ONLY_SOURCES.has(normalized.source)
+      ) {
+        throw new CloudglueError(
+          `URL '${url}' resolves through a data connector ('${normalized.source}') and cannot be synced anonymously. Use dataConnectors.syncFile(connectorId, url) or dataConnectors.syncUrl(url) instead.` +
+            (normalized.warnings.length
+              ? '\n' + normalized.warnings.join('\n')
+              : ''),
+          400,
+        );
+      }
+    }
+
+    const body: {
+      url: string;
+      metadata?: Record<string, any>;
+      enable_segment_thumbnails?: boolean;
+    } = { url: driveUc ? url : normalized.url };
+    if (params.metadata !== undefined) {
+      body.metadata = params.metadata;
+    }
+    if (params.enable_segment_thumbnails !== undefined) {
+      body.enable_segment_thumbnails = params.enable_segment_thumbnails;
+    }
+    return this.api.syncFileFromUrl(body);
   }
 
   async getFile(fileId: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,11 @@ export type * from './types';
 export * from './enums';
 
 /**
+ * Error class wrapping API errors with response metadata
+ */
+export * from './error';
+
+/**
  * URL classification and normalization utilities mirroring the API's
  * server-side URL handling
  */

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -43,7 +43,9 @@ export interface NormalizedVideoUrl {
 const YOUTUBE_VIDEO_REGEX =
   /^https?:\/\/(?:www\.)?(?:youtube\.com\/(?:watch\?(?:[^&]*&)*v=|embed\/|v\/|shorts\/|live\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/;
 const ZOOM_HTTPS_REGEX =
-  /^https:\/\/([a-z0-9-]+\.)?zoom\.us\/(j\/|s\/|recording\/detail)/i;
+  /^https:\/\/([a-z0-9-]+\.)?zoom\.us\/(j\/|s\/|recording\/detail|rec\/share\/)/i;
+const DROPBOX_FILE_SHARE_REGEX =
+  /^https?:\/\/(?:www\.)?dropbox\.com\/(?:scl\/fi\/|s\/)/i;
 const TIKTOK_URL_REGEX =
   /^https?:\/\/(?:(?:www\.)?tiktok\.com\/(?:t\/|@[^/]+\/video\/)|(?:vm|vt)\.tiktok\.com\/)/i;
 const LOOM_SHARE_URL_REGEX =
@@ -58,8 +60,9 @@ export const CONNECTOR_SYNC_URI_GRAMMAR: Record<string, string> = {
   s3: 's3://<bucket>/<key>',
   gcs: 'gs://<bucket>/<key>',
   'google-drive': 'gdrive://file/<fileId>',
-  dropbox: 'dropbox://<path>',
-  zoom: 'zoom://uuid/<meetingUuid>, zoom://id/<meetingId>, or https://*.zoom.us/{j|s|recording/detail}/... links',
+  dropbox:
+    'dropbox://<path>, or https://www.dropbox.com/{scl/fi|s}/... file share links',
+  zoom: 'zoom://uuid/<meetingUuid>, zoom://id/<meetingId>, or https://*.zoom.us/{j|s|recording/detail|rec/share}/... links',
   grain: 'grain://recording/<recordingId>',
   gong: 'gong://call/<callId>',
   recall: 'recall://recording/<recordingId>',
@@ -91,9 +94,12 @@ export function classifyVideoUrl(url: string): VideoUrlSource | null {
   if (YOUTUBE_VIDEO_REGEX.test(url)) return 'youtube';
   if (url.startsWith('s3://')) return 's3';
   // The server matches dl.dropboxusercontent.com as a substring; match on the
-  // hostname instead so unrelated URLs embedding that string classify as http
+  // hostname instead so unrelated URLs embedding that string classify as http.
+  // File share links (/scl/fi/, /s/) resolve through a Dropbox connector's
+  // OAuth; folder share links (/scl/fo/) stay http and fail server-side.
   if (
     url.startsWith('dropbox://') ||
+    DROPBOX_FILE_SHARE_REGEX.test(url) ||
     tryParseUrl(url)?.hostname === 'dl.dropboxusercontent.com'
   )
     return 'dropbox';
@@ -154,7 +160,10 @@ function rewriteS3Url(parsed: URL): string | null {
 
 function rewriteGcsUrl(parsed: URL): string | null {
   const host = parsed.hostname;
-  if (host === 'storage.googleapis.com' || host === 'storage.cloud.google.com') {
+  if (
+    host === 'storage.googleapis.com' ||
+    host === 'storage.cloud.google.com'
+  ) {
     const path = tryDecodeURIComponent(parsed.pathname.replace(/^\//, ''));
     if (path === null) return null;
     const slashIdx = path.indexOf('/');
@@ -181,7 +190,9 @@ function rewriteDropboxPreviewUrl(parsed: URL): string | null {
   //   /preview/<path>?...            → dropbox:///<path>
   //   /home/<folder>?preview=<file>  → dropbox:///<folder>/<file>
   if (parsed.pathname.startsWith('/preview/')) {
-    const path = tryDecodeURIComponent(parsed.pathname.slice('/preview'.length));
+    const path = tryDecodeURIComponent(
+      parsed.pathname.slice('/preview'.length),
+    );
     if (path === null || path.length <= 1) return null;
     return `dropbox://${path}`;
   }
@@ -203,9 +214,7 @@ function rewriteGrainShareUrl(parsed: URL): string | null {
   // The token only grants anonymous web access; the API resolves the id via
   // the connected workspace, so this works when the recording is accessible
   // to the connected Grain account.
-  const match = parsed.pathname.match(
-    /^\/share\/recording\/([a-zA-Z0-9_-]+)/,
-  );
+  const match = parsed.pathname.match(/^\/share\/recording\/([a-zA-Z0-9_-]+)/);
   if (match) return `grain://recording/${match[1]}`;
   return null;
 }
@@ -232,7 +241,12 @@ function collectWarnings(url: string, warnings: string[]): void {
       parsed.pathname.startsWith('/s/')
     ) {
       warnings.push(
-        'Dropbox share links are treated as generic HTTP downloads: they work with general ingestion methods (e.g. collections.addMediaByUrl) only when the link is publicly accessible, and cannot be used with dataConnectors.syncFile(). To sync via a Dropbox connector, use the dropbox:// URI returned by dataConnectors.listFiles().',
+        'Dropbox file share links sync through a Dropbox data connector via OAuth (dataConnectors.syncFile()/syncUrl()), including login-gated links. Without a connector they work with general ingestion methods (e.g. files.syncFromUrl, collections.addMediaByUrl) only when the link is publicly accessible.',
+      );
+    }
+    if (parsed.pathname.startsWith('/scl/fo/')) {
+      warnings.push(
+        'Dropbox folder share links (/scl/fo/...) are not supported. Share a single file, or use the dropbox:// file URIs returned by dataConnectors.listFiles().',
       );
     }
   }
@@ -248,9 +262,15 @@ function collectWarnings(url: string, warnings: string[]): void {
     (host === 'zoom.us' || host.endsWith('.zoom.us')) &&
     parsed.pathname.startsWith('/rec/')
   ) {
-    warnings.push(
-      'Zoom recording share links (zoom.us/rec/...) are not supported. Use a zoom://uuid/<meetingUuid> URI from dataConnectors.listFiles(), or a https://*.zoom.us/{j|s|recording/detail} link.',
-    );
+    if (parsed.pathname.startsWith('/rec/share/')) {
+      warnings.push(
+        'Zoom /rec/share/ links are resolved best-effort: Zoom often mints a new share token each time a link is copied from the portal, so the link may not resolve (404). The reliable form is the recording-detail link (https://*.zoom.us/recording/detail?meeting_id=<uuid>), which works for any recording age.',
+      );
+    } else {
+      warnings.push(
+        'Zoom recording links of this form (e.g. zoom.us/rec/play/...) are not supported. Use a zoom://uuid/<meetingUuid> URI from dataConnectors.listFiles(), or a https://*.zoom.us/{j|s|recording/detail|rec/share} link.',
+      );
+    }
   }
 }
 
@@ -271,7 +291,8 @@ function collectWarnings(url: string, warnings: string[]): void {
  *   `https://www.loom.com/share/<id>`
  *
  * Everything else passes through unchanged. `warnings` flags URL forms with
- * known limitations (e.g. Dropbox share links, Zoom `/rec/` links).
+ * known limitations (e.g. Dropbox folder links, Zoom `/rec/play/` links,
+ * best-effort Zoom `/rec/share/` tokens).
  */
 export function normalizeVideoUrl(url: string): NormalizedVideoUrl {
   const warnings: string[] = [];

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -68,6 +68,17 @@ export const CONNECTOR_SYNC_URI_GRAMMAR: Record<string, string> = {
   recall: 'recall://recording/<recordingId>',
 };
 
+/**
+ * True for https Dropbox *file share* links (`dropbox.com/scl/fi/...`,
+ * `/s/...`) — the only `dropbox`-classified URL form that general ingestion
+ * endpoints accept without a connector (when the link is public). Other
+ * dropbox forms (`dropbox://` URIs, `dl.dropboxusercontent.com` URLs)
+ * resolve only through a Dropbox data connector.
+ */
+export function isDropboxFileShareLink(url: string): boolean {
+  return DROPBOX_FILE_SHARE_REGEX.test(url);
+}
+
 function tryParseUrl(url: string): URL | null {
   try {
     return new URL(url);

--- a/test/data-connectors.test.ts
+++ b/test/data-connectors.test.ts
@@ -4,7 +4,9 @@ import assert from 'node:assert/strict';
 import { EnhancedDataConnectorsApi } from '../src/api/data-connectors.api';
 import { CloudglueError } from '../src/error';
 
-function makeApi(connectors: Array<{ id: string; type: string; created_at: number }>) {
+function makeApi(
+  connectors: Array<{ id: string; type: string; created_at: number }>,
+) {
   const calls: Array<{ url: string; connectorId: string }> = [];
   const api = {
     listDataConnectors: async () => ({ object: 'list', data: connectors }),
@@ -41,7 +43,9 @@ describe('dataConnectors.syncUrl', () => {
     ]);
     const client = new EnhancedDataConnectorsApi(api);
 
-    await client.syncUrl('https://drive.google.com/file/d/abc123/view?usp=sharing');
+    await client.syncUrl(
+      'https://drive.google.com/file/d/abc123/view?usp=sharing',
+    );
 
     assert.deepEqual(calls, [
       { url: 'gdrive://file/abc123', connectorId: 'gdrive_1' },
@@ -57,7 +61,8 @@ describe('dataConnectors.syncUrl', () => {
     await assert.rejects(
       client.syncUrl('s3://bucket/key.mp4'),
       (err: unknown) =>
-        err instanceof CloudglueError && /No 's3' data connector/.test(err.message),
+        err instanceof CloudglueError &&
+        /No 's3' data connector/.test(err.message),
     );
   });
 
@@ -69,17 +74,54 @@ describe('dataConnectors.syncUrl', () => {
 
     for (const url of [
       'https://example.com/video.mp4',
-      'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
-      'https://www.dropbox.com/scl/fi/abc/video.mp4?dl=0',
+      'https://www.tiktok.com/@user/video/7123456789012345678',
+      'https://www.dropbox.com/scl/fo/abc/folder?dl=0',
     ]) {
       await assert.rejects(
         client.syncUrl(url),
         (err: unknown) =>
           err instanceof CloudglueError &&
-          /cannot be synced through a data connector/.test(err.message),
+          /cannot be synced through a data connector/.test(err.message) &&
+          /files\.syncFromUrl/.test(err.message),
       );
     }
     assert.equal(calls.length, 0);
+  });
+
+  it('points YouTube URLs at collections.addMediaByUrl', async () => {
+    const { api, calls } = makeApi([]);
+    const client = new EnhancedDataConnectorsApi(api);
+
+    await assert.rejects(
+      client.syncUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ'),
+      (err: unknown) =>
+        err instanceof CloudglueError && /addMediaByUrl/.test(err.message),
+    );
+    assert.equal(calls.length, 0);
+  });
+
+  it('routes dropbox file share links to a dropbox connector verbatim', async () => {
+    const { api, calls } = makeApi([
+      { id: 'dropbox_1', type: 'dropbox', created_at: 500 },
+    ]);
+    const client = new EnhancedDataConnectorsApi(api);
+
+    const url = 'https://www.dropbox.com/scl/fi/abc/video.mp4?rlkey=x&dl=0';
+    await client.syncUrl(url);
+
+    assert.deepEqual(calls, [{ url, connectorId: 'dropbox_1' }]);
+  });
+
+  it('routes zoom rec/share links to a zoom connector verbatim', async () => {
+    const { api, calls } = makeApi([
+      { id: 'zoom_1', type: 'zoom', created_at: 500 },
+    ]);
+    const client = new EnhancedDataConnectorsApi(api);
+
+    const url = 'https://us02web.zoom.us/rec/share/abcdef';
+    await client.syncUrl(url);
+
+    assert.deepEqual(calls, [{ url, connectorId: 'zoom_1' }]);
   });
 });
 

--- a/test/files-sync.test.ts
+++ b/test/files-sync.test.ts
@@ -114,6 +114,8 @@ describe('files.syncFromUrl', () => {
       'https://drive.google.com/file/d/1a2bC3dE4f/view',
       'https://grain.com/share/recording/abc-123/token',
       'https://www.dropbox.com/preview/folder/video.mp4',
+      // dropbox CDN URLs are connector-only, unlike dropbox.com share links
+      'https://dl.dropboxusercontent.com/1/view/abc/test/video.mp4',
     ]) {
       await assert.rejects(
         client.syncFromUrl(url),

--- a/test/files-sync.test.ts
+++ b/test/files-sync.test.ts
@@ -1,0 +1,153 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { EnhancedFilesApi } from '../src/api/files.api';
+import { CloudglueError } from '../src/error';
+
+function makeApi() {
+  const calls: Array<Record<string, unknown>> = [];
+  const api = {
+    syncFileFromUrl: async (body: Record<string, unknown>) => {
+      calls.push(body);
+      return { id: 'file_1', object: 'file' };
+    },
+  };
+  return { api: api as any, calls };
+}
+
+describe('files.syncFromUrl', () => {
+  it('sends direct media URLs unchanged', async () => {
+    const { api, calls } = makeApi();
+    const client = new EnhancedFilesApi(api);
+
+    await client.syncFromUrl('https://example.com/video.mp4');
+
+    assert.deepEqual(calls, [{ url: 'https://example.com/video.mp4' }]);
+  });
+
+  it('includes metadata and enable_segment_thumbnails only when provided', async () => {
+    const { api, calls } = makeApi();
+    const client = new EnhancedFilesApi(api);
+
+    await client.syncFromUrl('https://example.com/video.mp4', {
+      metadata: { project: 'demo' },
+      enable_segment_thumbnails: false,
+    });
+
+    assert.deepEqual(calls, [
+      {
+        url: 'https://example.com/video.mp4',
+        metadata: { project: 'demo' },
+        enable_segment_thumbnails: false,
+      },
+    ]);
+  });
+
+  it('canonicalizes loom links before sending', async () => {
+    const { api, calls } = makeApi();
+    const client = new EnhancedFilesApi(api);
+
+    await client.syncFromUrl(
+      'https://loom.com/share/0281766fa2d04bb788eaf19e65135184',
+    );
+
+    assert.deepEqual(calls, [
+      { url: 'https://www.loom.com/share/0281766fa2d04bb788eaf19e65135184' },
+    ]);
+  });
+
+  it('sends tiktok URLs unchanged', async () => {
+    const { api, calls } = makeApi();
+    const client = new EnhancedFilesApi(api);
+
+    const url = 'https://www.tiktok.com/@user/video/7123456789012345678';
+    await client.syncFromUrl(url);
+
+    assert.deepEqual(calls, [{ url }]);
+  });
+
+  it('sends public dropbox file share links unchanged', async () => {
+    const { api, calls } = makeApi();
+    const client = new EnhancedFilesApi(api);
+
+    const url = 'https://www.dropbox.com/scl/fi/abc/video.mp4?rlkey=x&dl=0';
+    await client.syncFromUrl(url);
+
+    assert.deepEqual(calls, [{ url }]);
+  });
+
+  it('sends drive uc?id= links unchanged (anonymous http path)', async () => {
+    const { api, calls } = makeApi();
+    const client = new EnhancedFilesApi(api);
+
+    const url = 'https://drive.google.com/uc?export=download&id=1a2bC3dE4f';
+    await client.syncFromUrl(url);
+
+    assert.deepEqual(calls, [{ url }]);
+  });
+
+  it('rejects YouTube URLs with a pointer to collections', async () => {
+    const { api, calls } = makeApi();
+    const client = new EnhancedFilesApi(api);
+
+    await assert.rejects(
+      client.syncFromUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ'),
+      (err: unknown) =>
+        err instanceof CloudglueError && /addMediaByUrl/.test(err.message),
+    );
+    assert.equal(calls.length, 0);
+  });
+
+  it('rejects connector-native URLs with a pointer to dataConnectors', async () => {
+    const { api, calls } = makeApi();
+    const client = new EnhancedFilesApi(api);
+
+    for (const url of [
+      's3://my-bucket/video.mp4',
+      'gs://my-bucket/video.mp4',
+      'gdrive://file/abc',
+      'dropbox:///test/video.mp4',
+      'grain://recording/abc-123',
+      // https forms that resolve through a connector
+      'https://us02web.zoom.us/j/123456789',
+      'https://us02web.zoom.us/rec/share/abcdef',
+      'https://drive.google.com/file/d/1a2bC3dE4f/view',
+      'https://grain.com/share/recording/abc-123/token',
+      'https://www.dropbox.com/preview/folder/video.mp4',
+    ]) {
+      await assert.rejects(
+        client.syncFromUrl(url),
+        (err: unknown) =>
+          err instanceof CloudglueError &&
+          /dataConnectors\.sync/.test(err.message),
+      );
+    }
+    assert.equal(calls.length, 0);
+  });
+
+  it('rejects cloudglue file URIs', async () => {
+    const { api, calls } = makeApi();
+    const client = new EnhancedFilesApi(api);
+
+    await assert.rejects(
+      client.syncFromUrl(
+        'cloudglue://files/123e4567-e89b-12d3-a456-426614174000',
+      ),
+      (err: unknown) =>
+        err instanceof CloudglueError && /already references/.test(err.message),
+    );
+    assert.equal(calls.length, 0);
+  });
+
+  it('rejects non-URL input', async () => {
+    const { api, calls } = makeApi();
+    const client = new EnhancedFilesApi(api);
+
+    await assert.rejects(
+      client.syncFromUrl('not a url'),
+      (err: unknown) =>
+        err instanceof CloudglueError && /not a valid/.test(err.message),
+    );
+    assert.equal(calls.length, 0);
+  });
+});

--- a/test/url-utils.test.ts
+++ b/test/url-utils.test.ts
@@ -33,12 +33,17 @@ describe('classifyVideoUrl', () => {
     ['grain://recording/abc-123', 'grain'],
     ['https://example.com/video.mp4', 'http'],
     ['http://example.com/video.mp4', 'http'],
-    // share links the server treats as generic http
+    // dropbox file share links resolve via a connector's OAuth (API 0.7.5)
     [
       'https://www.dropbox.com/scl/fi/r85h2r4d9s13la63r5pzf/video.mp4?rlkey=x&dl=0',
-      'http',
+      'dropbox',
     ],
-    ['https://zoom.us/rec/share/abcdef', 'http'],
+    ['https://www.dropbox.com/s/abc123/video.mp4?dl=0', 'dropbox'],
+    // ...but folder share links stay http and fail server-side
+    ['https://www.dropbox.com/scl/fo/abc123/folder?rlkey=x&dl=0', 'http'],
+    // zoom rec/share links are connector-syncable (best-effort); rec/play is not
+    ['https://zoom.us/rec/share/abcdef', 'zoom'],
+    ['https://us02web.zoom.us/rec/play/abcdef', 'http'],
     // loom without www / http scheme falls through to http
     ['https://loom.com/share/0281766fa2d04bb788eaf19e65135184', 'http'],
     // hostname must actually be dl.dropboxusercontent.com, not a substring elsewhere
@@ -243,20 +248,31 @@ describe('normalizeVideoUrl pass-throughs', () => {
 });
 
 describe('normalizeVideoUrl warnings', () => {
-  it('warns on www.dropbox.com share links (scl/fi form)', () => {
+  it('notes the public-only anonymous path on dropbox file share links (scl/fi form)', () => {
     const result = normalizeVideoUrl(
       'https://www.dropbox.com/scl/fi/r85h2r4d9s13la63r5pzf/video.mp4?rlkey=x&dl=0',
     );
-    assert.equal(result.source, 'http');
+    assert.equal(result.source, 'dropbox');
     assert.equal(result.warnings.length, 1);
     assert.match(result.warnings[0], /syncFile/);
+    assert.match(result.warnings[0], /publicly accessible/);
   });
 
-  it('warns on legacy /s/ dropbox share links', () => {
+  it('notes the public-only anonymous path on legacy /s/ dropbox share links', () => {
     const result = normalizeVideoUrl(
       'https://www.dropbox.com/s/abc123/video.mp4?dl=0',
     );
+    assert.equal(result.source, 'dropbox');
     assert.equal(result.warnings.length, 1);
+  });
+
+  it('warns on dropbox folder share links (scl/fo form)', () => {
+    const result = normalizeVideoUrl(
+      'https://www.dropbox.com/scl/fo/abc123/folder?rlkey=x&dl=0',
+    );
+    assert.equal(result.source, 'http');
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /folder/i);
   });
 
   it('warns on non-/1/view dl.dropboxusercontent.com URLs', () => {
@@ -275,11 +291,20 @@ describe('normalizeVideoUrl warnings', () => {
     assert.equal(result.warnings.length, 0);
   });
 
-  it('warns on zoom.us/rec/ recording links', () => {
+  it('notes best-effort resolution on zoom.us/rec/share links', () => {
     const result = normalizeVideoUrl('https://us02web.zoom.us/rec/share/abc');
+    assert.equal(result.source, 'zoom');
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /best-effort/i);
+    assert.match(result.warnings[0], /recording\/detail/);
+  });
+
+  it('warns on unsupported zoom.us/rec/play links', () => {
+    const result = normalizeVideoUrl('https://us02web.zoom.us/rec/play/abc');
     assert.equal(result.source, 'http');
     assert.equal(result.warnings.length, 1);
-    assert.match(result.warnings[0], /zoom/i);
+    assert.match(result.warnings[0], /not supported/i);
+    assert.match(result.warnings[0], /recording\/detail/);
   });
 
   it('produces no warnings for clean URLs', () => {
@@ -294,7 +319,16 @@ describe('CONNECTOR_SYNC_URI_GRAMMAR', () => {
   it('covers all connector types', () => {
     assert.deepEqual(
       Object.keys(CONNECTOR_SYNC_URI_GRAMMAR).sort(),
-      ['dropbox', 'gcs', 'gong', 'google-drive', 'grain', 'recall', 's3', 'zoom'].sort(),
+      [
+        'dropbox',
+        'gcs',
+        'gong',
+        'google-drive',
+        'grain',
+        'recall',
+        's3',
+        'zoom',
+      ].sort(),
     );
   });
 });


### PR DESCRIPTION
## Summary

Bumps the SDK to 0.7.15 on spec v0.7.5 ([cloudglue-api-spec#99](https://github.com/cloudglue/cloudglue-api-spec/pull/99), merged — submodule pinned to the `main` commit `7ecd8ae`; API changes from cloudglue PR #1186) and adds wrapper-layer support for the new URL handling.

### New: `files.syncFromUrl()`

Wraps the new `POST /files/sync` endpoint — materializes a publicly accessible URL (direct media URLs, public Dropbox share links, TikTok, Loom) into a Cloudglue file without a connector or collection. Idempotent; chains with `waitForReady()`.

Client-side routing guard mirrors the API's documented 400s before any request is sent:
- YouTube → points to `collections.addMediaByUrl()`
- Connector-native URLs (URI schemes, Zoom/Grain links, Drive file links, Dropbox preview links) → points to `dataConnectors.syncFile()/syncUrl()`
- Non-canonical Loom links are rewritten to the accepted form; Drive `uc?id=` links are special-cased to stay on the anonymous http path

### Connector sync: newly accepted share-link forms

- Dropbox file share links (`/scl/fi/`, `/s/`) now classify as `dropbox` and Zoom `/rec/share/` links as `zoom`, so `dataConnectors.syncFile()/syncUrl()` pass them through for server-side resolution via the connector's OAuth (previously the client-side guard rejected them)
- Warnings updated: OAuth vs public-link nuance on share links, `/scl/fo/` folder-link and `/rec/play/` guidance, best-effort note on `/rec/share/` tokens
- Connector sync rejection messages now route plain/TikTok/Loom URLs to `files.syncFromUrl()`

### Fixes

- `CloudglueError` is now exported from the package index — `docs/errors.md` documented this import, but it was never actually exported

### Docs & tests

- Docs updated: `files`, `other-sources`, `data-connectors`, `errors` (new URL-ingestion error table: 400 variants/402/403/415/429/502, unsupported video-page hosts), `overview`
- Tests: new `test/files-sync.test.ts` for the routing guard; updated classification/warning/routing expectations (106 tests, all passing)

## Verification

Ran live against the API with a smoke-test script:
- `files.syncFromUrl`: direct `.mp4`, TikTok, and non-canonical Loom URLs all synced and completed; re-sync returned the same file ID (idempotent)
- `dataConnectors.syncUrl`: Drive share link synced via the google-drive connector; Dropbox preview link and `scl/fi` share link both synced and **deduped to the same file**; Zoom `rec/share` links returned the documented best-effort 404 guidance (stale tokens)

The merged spec commit is content-identical to the PR head the clients were generated from, so no regeneration was needed after the submodule bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes URL classification and client-side routing across files and data-connector sync paths; mis-routing could send users to the wrong endpoint, but behavior is covered by extensive tests and mostly fails fast with guided errors.
> 
> **Overview**
> Bumps the SDK to **0.7.15** (OpenAPI **0.7.5**) and adds **`client.files.syncFromUrl()`** for `POST /files/sync`, so direct media URLs, public Dropbox file shares, TikTok, and Loom can become standalone Cloudglue files without a connector or collection. The wrapper rejects bad inputs early (YouTube → `collections.addMediaByUrl()`, connector-native URLs → `dataConnectors.syncFile()`/`syncUrl()`), rewrites Loom links, and keeps Drive `uc?id=` on the anonymous HTTP path.
> 
> **Connector share-link behavior** is aligned with the API: Dropbox `/scl/fi/` and `/s/` links classify as `dropbox` and Zoom `/rec/share/` as `zoom`, so `dataConnectors` sync can pass them through for OAuth resolution instead of blocking them client-side. `normalizeVideoUrl` warnings and connector rejection messages now explain OAuth vs public access, folder links, and best-effort Zoom share tokens.
> 
> Also **exports `CloudglueError`** from the package entry (docs already referenced it), regenerates Zodios clients for the new endpoint and richer sync error codes, and expands docs/tests for URL ingestion errors and routing guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f46cd7b59283a861995f1d4d21aac357377bb89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->