### PR TITLE
Support shorter shots (spec v0.7.6)

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -60,7 +60,7 @@ const result = await client.segments.createSegmentJob({
   criteria: 'shot',
   shot_config: {
     detector: 'adaptive',              // 'adaptive' or 'content'
-    min_duration_seconds: 2,           // 1-600
+    min_duration_seconds: 2,           // 0.6-600
     max_duration_seconds: 30,          // 1-600
     fill_gaps: true,
   },

--- a/generated/Segments.ts
+++ b/generated/Segments.ts
@@ -61,8 +61,8 @@ type SegmentsListItem = {
 const ShotConfig: z.ZodType<ShotConfig> = z
   .object({
     detector: z.enum(['content', 'adaptive']),
-    max_duration_seconds: z.number().int().gte(1).lte(600),
-    min_duration_seconds: z.number().int().gte(1).lte(600),
+    max_duration_seconds: z.number().gte(1).lte(600),
+    min_duration_seconds: z.number().gte(0.6).lte(600),
     fill_gaps: z.boolean(),
   })
   .partial()

--- a/generated/common.ts
+++ b/generated/common.ts
@@ -459,7 +459,7 @@ export const SegmentationUniformConfig = z
 export const SegmentationShotDetectorConfig = z
   .object({
     threshold: z.number().nullish(),
-    min_seconds: z.number().gte(1).lte(600).nullish(),
+    min_seconds: z.number().gte(0.6).lte(600).nullish(),
     max_seconds: z.number().gte(1).lte(600).nullish(),
     detector: z.enum(['adaptive', 'content']),
     fill_gaps: z.boolean().optional(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.15",
+      "version": "0.7.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Summary
- Regenerated clients from spec v0.7.6 ("Support shorter shots"): `min_duration_seconds` / `min_seconds` minimum lowered from 1s to 0.6s, and shot duration fields changed from integer to number
- Bumped package version to 0.7.16
- Updated `docs/advanced.md` to reflect the new 0.6-600 bound

## Verification
- `npm run generate` against the new spec produces zero diff (generated files fully in sync)
- `npm run build` compiles cleanly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated schema and doc bound updates only; no runtime client logic changes beyond looser validation for shot duration config.
> 
> **Overview**
> Syncs the JS client with **OpenAPI spec v0.7.6** (“Support shorter shots”) and releases **0.7.16**.
> 
> **Shot segmentation validation** now allows **sub-second minimums**: `min_duration_seconds` (segments jobs) and `min_seconds` (shot-detector file segmentation) accept **0.6–600** instead of **1–600**. **`max_duration_seconds`** drops the integer constraint so durations can be fractional numbers, matching the API.
> 
> `docs/advanced.md` documents the new **0.6–600** bound for `min_duration_seconds`. `package.json` / lockfile version bump only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32598414125928babda2f019ef3bb5593233182e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->