### PR TITLE
feat: support image files (spec v0.7.8)

### DIFF
--- a/docs/describe.md
+++ b/docs/describe.md
@@ -4,6 +4,8 @@ Generate rich multimodal descriptions of video content including speech transcri
 
 **Note:** The `transcribe` API is deprecated. Use `describe` instead.
 
+**Images:** `createDescribe` also accepts images — pass an uploaded image's `cloudglue://files/<id>` URI or a direct public image URL. Images are described at the file level (no segmentation), so omit `segmentation_config`/`include_shots`/`include_chapters`; the visual modalities (`visual_scene_description`, `scene_text`, `summary`, `title`) are populated and speech/audio come back empty. Image describe jobs often complete synchronously, so the create response may already be `completed` — `waitForReady` still works either way.
+
 ## Create a Describe Job
 
 ```typescript

--- a/docs/extract.md
+++ b/docs/extract.md
@@ -2,6 +2,8 @@
 
 Extract structured data from videos using custom prompts and schemas.
 
+**Images:** `createExtract` also accepts images — pass an uploaded image's `cloudglue://files/<id>` URI or a direct public image URL. Images aren't segmented, so use whole-file extraction (`enable_video_level_entities: true`, `enable_segment_level_entities: false`); `segment_entities` comes back empty.
+
 ## Create an Extract Job
 
 ```typescript

--- a/docs/files.md
+++ b/docs/files.md
@@ -1,12 +1,12 @@
 # Files API
 
-Manage video and audio files in Cloudglue.
+Manage video, audio, and image files in Cloudglue.
 
 ## Upload a File
 
 ```typescript
 const uploaded = await client.files.uploadFile({
-  file: myFile,                        // globalThis.File object
+  file: myFile,                        // globalThis.File object (video, audio, or image)
   metadata: { project: 'demo' },      // optional key-value metadata
   enable_segment_thumbnails: true,     // optional: generate thumbnails per segment
 });
@@ -16,6 +16,12 @@ const file = await client.files.waitForReady(uploaded.data.id);
 ```
 
 **Note:** File uploads use `multipart/form-data` via axios directly (not Zodios). The `file` parameter must be a `globalThis.File` object.
+
+### Image files
+
+Images (JPEG/PNG/WebP, …) upload through the same `uploadFile`/`syncFromUrl`/`waitForReady` flow as video and audio. On the returned file, `media_type === 'image'` and `media_info` carries `width`/`height` (with `duration_seconds` ≈ 0 and `has_audio: false`).
+
+Images are processed **at the file level only** — they are not segmented. As a result they have no segments, no per-segment thumbnails, and `enable_segment_thumbnails` is ignored. Describe and extract still work on images: pass the file's `cloudglue://files/<id>` URI (or a direct public image URL) to `describe.createDescribe()` / `extract.createExtract()`. Visual modalities (`visual_scene_description`, `scene_text`, `summary`, `title`) are populated; speech/audio modalities come back empty.
 
 ## Sync from URL
 
@@ -32,10 +38,12 @@ const ready = await client.files.waitForReady(file.id);
 
 Accepted URL forms:
 
-- Direct http(s) video/audio file URLs (e.g. `.mp4`)
+- Direct http(s) video, audio, or image file URLs (e.g. `.mp4`, `.jpg`/`.png`/`.webp`)
 - Public Dropbox share links (`dropbox.com/scl/fi/...`, `/s/...`)
 - TikTok video URLs (consumes scrape credits — 402 if the balance is insufficient)
 - Loom share URLs (non-canonical forms are rewritten client-side)
+
+The host must serve the bytes to an anonymous request. Image URLs gated behind a browser User-Agent (e.g. some Wikimedia links) are rejected server-side as `Unsupported file type`.
 
 Not accepted — the SDK rejects these client-side with guidance:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,13 +5,13 @@ Cloudglue turns video into LLM-ready data. This SDK (`@cloudglue/cloudglue-js`) 
 ## Mental Model
 
 ```text
-Files (upload video/audio, video URL, data connector URI)
+Files (upload video/audio/image, media URL, data connector URI)
   → Processing (describe, extract, face detection)
     → Collections (group processed files)
       → Querying (chat, search, deep search, responses API)
 ```
 
-1. **Upload** a video file, provide a URL, or provide a data connector URI
+1. **Upload** a video, audio, or image file, provide a URL, or provide a data connector URI
 2. **Process** it with describe (multimodal descriptions) or extract (structured data)
 3. **Organize** files into collections
 4. **Query** collections via chat, search, deep search, or the Responses API
@@ -36,7 +36,7 @@ The SDK also exports standalone URL helpers (`classifyVideoUrl`, `normalizeVideo
 
 | Namespace | Purpose | Key Methods |
 |-----------|---------|-------------|
-| `client.files` | Upload & manage video files | `uploadFile`, `syncFromUrl`, `listFiles`, `getFile`, `deleteFile`, `waitForReady` |
+| `client.files` | Upload & manage video, audio & image files | `uploadFile`, `syncFromUrl`, `listFiles`, `getFile`, `deleteFile`, `waitForReady` |
 | `client.collections` | Organize videos into groups | `createCollection`, `addMedia`, `listVideos`, `waitForReady` |
 | `client.describe` | Multimodal video descriptions | `createDescribe`, `getDescribe`, `waitForReady` |
 | `client.extract` | Structured data extraction | `createExtract`, `getExtract`, `waitForReady` |

--- a/generated/Files.ts
+++ b/generated/Files.ts
@@ -328,12 +328,12 @@ const endpoints = makeApi([
     method: 'post',
     path: '/files',
     alias: 'uploadFile',
-    description: `Upload a video file that can be used with Cloudglue services`,
+    description: `Upload a video, audio, or image file that can be used with Cloudglue services`,
     requestFormat: 'form-data',
     parameters: [
       {
         name: 'body',
-        description: `Upload a video file`,
+        description: `Upload a video, audio, or image file`,
         type: 'Body',
         schema: FileUpload,
       },

--- a/generated/common.ts
+++ b/generated/common.ts
@@ -113,7 +113,7 @@ export type File = {
   filename?: string | undefined;
   uri: string;
   metadata?: ({} | null) | undefined;
-  media_type?: ('video' | 'audio') | undefined;
+  media_type?: ('video' | 'audio' | 'image') | undefined;
   media_info?:
     | Partial<{
         duration_seconds: number | null;
@@ -641,7 +641,7 @@ export const File = z
     filename: z.string().optional(),
     uri: z.string(),
     metadata: z.object({}).partial().strict().passthrough().nullish(),
-    media_type: z.enum(['video', 'audio']).optional(),
+    media_type: z.enum(['video', 'audio', 'image']).optional(),
     media_info: z
       .object({
         duration_seconds: z.number().nullable(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.17",
+      "version": "0.7.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/files.api.ts
+++ b/src/api/files.api.ts
@@ -13,10 +13,17 @@ import { isDropboxFileShareLink, normalizeVideoUrl } from '../url-utils';
 import type { AxiosResponse } from 'axios';
 
 type UploadFileParams = {
+  /**
+   * The file to upload. Accepts video, audio, and image files
+   * (e.g. JPEG/PNG/WebP). Images are processed at the file level only — they
+   * are not segmented, so they have no segments, segment thumbnails, or
+   * per-segment describe/extract outputs.
+   */
   file: globalThis.File;
   metadata?: Record<string, any>;
   /**
    * If enabled, the file will be segmented and thumbnails will be generated for each segment for the default segmentation config.
+   * Ignored for images, which are not segmented.
    */
   enable_segment_thumbnails?: boolean;
 };
@@ -124,10 +131,13 @@ export class EnhancedFilesApi {
 
   /**
    * Materialize a publicly accessible URL into a Cloudglue file without a
-   * data connector or a collection. Accepts direct http(s) video/audio file
-   * URLs (e.g. `.mp4`), public Dropbox share links, TikTok video URLs, and
-   * Loom share URLs. Idempotent: syncing the same URL returns the existing
-   * file. The returned file may still be processing — chain
+   * data connector or a collection. Accepts direct http(s) video, audio, or
+   * image file URLs (e.g. `.mp4`, `.jpg`/`.png`/`.webp`), public Dropbox share
+   * links, TikTok video URLs, and Loom share URLs. The host must serve the
+   * bytes to an anonymous request — links gated behind a browser User-Agent
+   * (e.g. some Wikimedia URLs) are rejected server-side as "Unsupported file
+   * type". Idempotent: syncing the same URL returns the existing file. The
+   * returned file may still be processing — chain
    * `files.waitForReady(file.id)` to wait for it.
    *
    * Non-canonical Loom links are rewritten client-side to the form the API


### PR DESCRIPTION
## Summary

Regenerates the low-level clients from API spec **v0.7.8** ([cloudglue-api-spec#102](https://github.com/cloudglue/cloudglue-api-spec/pull/102)), which adds **`image`** as a file `media_type` and accepts direct image URLs (JPEG/PNG/WebP) for upload, describe, and extract.

The high-level wrappers (`uploadFile`, `syncFromUrl`, `describe.createDescribe`, `extract.createExtract`) are generic pass-throughs, so images already flow through them — **no functional wrapper changes were needed**. This PR:

- Regenerates `generated/` from the new spec — `media_type` is now `video | audio | image`
- Updates JSDoc in `src/api/files.api.ts` and the embedded `docs/` to document image support: file-level only (images aren't segmented, so `enable_segment_thumbnails` is a no-op), and how to describe/extract an image via its `cloudglue://files/<id>` URI or a direct image URL
- Bumps the package to `0.7.18`

## Testing

- `npm run build` (clean) and `npm test` (106 passing)
- Smoke-tested image upload, `syncFromUrl`, and describe/extract — via both a `cloudglue://files/<id>` URI and a direct image URL — against the live API; all working as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly generated types, docs, and a patch version bump; no new wrapper logic beyond JSDoc.
> 
> **Overview**
> Adds **`image`** as a first-class file `media_type` (API spec v0.7.8): regenerated clients extend `File.media_type` to `video | audio | image`, and upload endpoint copy now covers images.
> 
> **Docs & JSDoc** spell out how images behave end-to-end: same `uploadFile` / `syncFromUrl` / `waitForReady` flow; `media_type === 'image'` with width/height; **no segmentation** (segment thumbnails ignored); describe/extract via `cloudglue://files/<id>` or public image URLs, with file-level describe (skip segmentation/shots/chapters) and video-level extract; note on User-Agent–gated image URLs failing sync.
> 
> Package version bumps **0.7.17 → 0.7.18**. High-level wrappers are unchanged beyond documentation—the pass-through APIs already accept the new inputs once types/spec are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b3fe77e261d404ad71941416546faa6fc3436b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->