### PR TITLE
ci: release workflow — build, publish to npm via OIDC, attach GitHub Release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,12 +75,30 @@ jobs:
           ls -lh *.tgz "${NAME}-dist.tar.gz" "${NAME}-dist.zip"
 
       - name: Publish to npm via OIDC trusted publishing
-        run: npm publish --access public
         # Do NOT add an `env: NODE_AUTH_TOKEN: ...` block here. With a Trusted Publisher
         # configured on npmjs.com, npm exchanges the GitHub OIDC token automatically and
         # attaches provenance. Setting NODE_AUTH_TOKEN to ANY value (even an empty string,
         # e.g. from a missing secret) makes npm use token auth instead of OIDC and the
         # publish fails. Leaving it unset is required, not just optional.
+        run: |
+          set +e
+          npm publish --access public
+          code=$?
+          set -e
+          if [ "$code" -ne 0 ]; then
+            # A re-run after a partial release (publish succeeded but a later step failed)
+            # would otherwise be stuck forever: publish errors on the existing version and
+            # the GitHub Release never gets created. If this exact version is already on the
+            # registry, treat publish as done and continue so the Release step can finish.
+            NAME="$(node -p "require('./package.json').name")"
+            VERSION="$(node -p "require('./package.json').version")"
+            if npm view "${NAME}@${VERSION}" version > /dev/null 2>&1; then
+              echo "::notice::${NAME}@${VERSION} is already on npm; continuing (re-run after a partial release)."
+            else
+              echo "::error::npm publish failed (exit ${code}) and ${NAME}@${VERSION} is not on npm."
+              exit "$code"
+            fi
+          fi
 
       - name: Create GitHub Release with build artifacts
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           node-version: '22' # resolves to >= 22.14.0, required for trusted publishing
           registry-url: 'https://registry.npmjs.org'
+          # registry-url is the npm-documented OIDC setup. It does NOT break OIDC as long
+          # as NODE_AUTH_TOKEN is never set (see the publish step) — npm prefers OIDC when
+          # no token is present. Crucially, do not pass `env: NODE_AUTH_TOKEN` to this step.
 
       - name: Upgrade npm to a trusted-publishing-capable version
         run: npm install --global npm@latest # OIDC trusted publishing needs npm >= 11.5.1
@@ -73,8 +76,11 @@ jobs:
 
       - name: Publish to npm via OIDC trusted publishing
         run: npm publish --access public
-        # No NODE_AUTH_TOKEN required: with a Trusted Publisher configured on npmjs.com,
-        # npm exchanges the GitHub OIDC token automatically and attaches provenance.
+        # Do NOT add an `env: NODE_AUTH_TOKEN: ...` block here. With a Trusted Publisher
+        # configured on npmjs.com, npm exchanges the GitHub OIDC token automatically and
+        # attaches provenance. Setting NODE_AUTH_TOKEN to ANY value (even an empty string,
+        # e.g. from a missing secret) makes npm use token auth instead of OIDC and the
+        # publish fails. Leaving it unset is required, not just optional.
 
       - name: Create GitHub Release with build artifacts
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,23 +81,18 @@ jobs:
         # e.g. from a missing secret) makes npm use token auth instead of OIDC and the
         # publish fails. Leaving it unset is required, not just optional.
         run: |
-          set +e
-          npm publish --access public
-          code=$?
-          set -e
-          if [ "$code" -ne 0 ]; then
-            # A re-run after a partial release (publish succeeded but a later step failed)
-            # would otherwise be stuck forever: publish errors on the existing version and
-            # the GitHub Release never gets created. If this exact version is already on the
-            # registry, treat publish as done and continue so the Release step can finish.
-            NAME="$(node -p "require('./package.json').name")"
-            VERSION="$(node -p "require('./package.json').version")"
-            if npm view "${NAME}@${VERSION}" version > /dev/null 2>&1; then
-              echo "::notice::${NAME}@${VERSION} is already on npm; continuing (re-run after a partial release)."
-            else
-              echo "::error::npm publish failed (exit ${code}) and ${NAME}@${VERSION} is not on npm."
-              exit "$code"
-            fi
+          NAME="$(node -p "require('./package.json').name")"
+          VERSION="$(node -p "require('./package.json').version")"
+          # Re-run safety, scoped narrowly: only SKIP publishing when this exact version is
+          # already on the registry — that is the partial-release case (publish succeeded but
+          # a later step failed), where re-running must not get stuck on a version conflict.
+          # In every other case we publish and let ANY failure (auth/OIDC/network/etc.) fail
+          # the job. We never swallow a publish error, so a GitHub Release is only created for
+          # a build that is genuinely on npm.
+          if [ -n "$(npm view "${NAME}@${VERSION}" version 2> /dev/null || true)" ]; then
+            echo "::notice::${NAME}@${VERSION} is already on npm; skipping publish (re-run after a partial release)."
+          else
+            npm publish --access public
           fi
 
       - name: Create GitHub Release with build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,10 @@ jobs:
         with:
           generate_release_notes: true
           fail_on_unmatched_files: true
+          # Mark prerelease tags (e.g. v1.0.0-rc.1) as a GitHub prerelease so they don't
+          # become the repo's "Latest" release — consistent with routing them to npm's
+          # `next` dist-tag in the publish step. The tag carries the version (verified above).
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             *.tgz
             *-dist.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,10 @@ jobs:
           # no token is present. Crucially, do not pass `env: NODE_AUTH_TOKEN` to this step.
 
       - name: Upgrade npm to a trusted-publishing-capable version
-        run: npm install --global npm@latest # OIDC trusted publishing needs npm >= 11.5.1
+        # OIDC trusted publishing needs npm >= 11.5.1. Pin to the 11 major (resolves to the
+        # latest 11.x) rather than @latest so a future npm major can't silently change
+        # publish/OIDC behavior on the one path that only runs at release time.
+        run: npm install --global npm@11
 
       - name: Verify the tag matches package.json version
         run: |
@@ -67,7 +70,9 @@ jobs:
       - name: Package dist build artifacts
         run: |
           NAME="cloudglue-cloudglue-js-${GITHUB_REF_NAME}"
-          # The npm-publishable tarball — exactly what gets published to the registry.
+          # A fresh pack of the built package, attached to the Release for convenience. It
+          # has the same contents as the published package, but is a separate pack run from
+          # the registry upload below, so don't rely on it being byte-identical to npm's.
           npm pack
           # Convenience archives of the compiled output for the GitHub Release.
           tar -czf "${NAME}-dist.tar.gz" dist docs README.md LICENSE.md package.json
@@ -83,16 +88,37 @@ jobs:
         run: |
           NAME="$(node -p "require('./package.json').name")"
           VERSION="$(node -p "require('./package.json').version")"
+
+          # Prereleases (e.g. v1.0.0-rc.1 — the v*.*.* trigger still matches them) must NOT
+          # land on the `latest` dist-tag, or a plain `npm install` would hand every user the
+          # unstable build. Route any semver prerelease (the version contains a hyphen) to the
+          # `next` tag; stable versions go to `latest`.
+          DIST_TAG="latest"
+          case "$VERSION" in
+            *-*) DIST_TAG="next" ;;
+          esac
+
           # Re-run safety, scoped narrowly: only SKIP publishing when this exact version is
-          # already on the registry — that is the partial-release case (publish succeeded but
-          # a later step failed), where re-running must not get stuck on a version conflict.
-          # In every other case we publish and let ANY failure (auth/OIDC/network/etc.) fail
-          # the job. We never swallow a publish error, so a GitHub Release is only created for
-          # a build that is genuinely on npm.
-          if [ -n "$(npm view "${NAME}@${VERSION}" version 2> /dev/null || true)" ]; then
+          # already on the registry — the partial-release case (publish succeeded but a later
+          # step failed), where re-running must not get stuck on a version conflict. We tell
+          # "definitely not published" (npm view returns E404) apart from "registry query
+          # failed" (network/5xx): only E404 is treated as safe-to-publish. A query failure
+          # is NOT assumed to mean absent, so a transient blip can't make a re-run try to
+          # publish over an existing version. Otherwise we publish and let any failure fail
+          # the job — a GitHub Release is only ever created for a build that is genuinely on npm.
+          ERRLOG="$RUNNER_TEMP/npm-view.err"
+          set +e
+          EXISTING="$(npm view "${NAME}@${VERSION}" version 2> "$ERRLOG")"
+          VIEW_CODE=$?
+          set -e
+          if [ "$VIEW_CODE" -eq 0 ] && [ -n "$EXISTING" ]; then
             echo "::notice::${NAME}@${VERSION} is already on npm; skipping publish (re-run after a partial release)."
+          elif grep -q "E404" "$ERRLOG"; then
+            npm publish --access public --tag "$DIST_TAG"
           else
-            npm publish --access public
+            echo "::error::Could not determine whether ${NAME}@${VERSION} is published; the npm registry query failed:"
+            cat "$ERRLOG"
+            exit 1
           fi
 
       - name: Create GitHub Release with build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # No step does an authenticated `git push`, so don't leave the repo-write token
+          # in git config where later build/test/publish steps could reach it. The Release
+          # step authenticates via GITHUB_TOKEN in the environment, not git credentials.
+          persist-credentials: false
         # generated/ is committed, so the spec/ submodule is not needed to build.
 
       - name: Set up Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,20 +105,25 @@ jobs:
 
           # Re-run safety, scoped narrowly: only SKIP publishing when this exact version is
           # already on the registry — the partial-release case (publish succeeded but a later
-          # step failed), where re-running must not get stuck on a version conflict. We tell
-          # "definitely not published" (npm view returns E404) apart from "registry query
-          # failed" (network/5xx): only E404 is treated as safe-to-publish. A query failure
-          # is NOT assumed to mean absent, so a transient blip can't make a re-run try to
-          # publish over an existing version. Otherwise we publish and let any failure fail
-          # the job — a GitHub Release is only ever created for a build that is genuinely on npm.
+          # step failed), where re-running must not get stuck on a version conflict. Ask npm
+          # for the full published version list and test membership, rather than parsing a
+          # per-version 404 string, so the normal-release decision never depends on npm's
+          # error wording. exit 0 = authoritative answer; a never-published package returns
+          # E404 (publish the first version); any other failure (network/5xx) is fatal, so a
+          # transient blip can neither skip a real release nor publish over an existing one.
           ERRLOG="$RUNNER_TEMP/npm-view.err"
           set +e
-          EXISTING="$(npm view "${NAME}@${VERSION}" version 2> "$ERRLOG")"
+          VERSIONS_JSON="$(npm view "${NAME}" versions --json 2> "$ERRLOG")"
           VIEW_CODE=$?
           set -e
-          if [ "$VIEW_CODE" -eq 0 ] && [ -n "$EXISTING" ]; then
-            echo "::notice::${NAME}@${VERSION} is already on npm; skipping publish (re-run after a partial release)."
+          if [ "$VIEW_CODE" -eq 0 ]; then
+            if node -e 'const [v,j]=process.argv.slice(1);let a;try{a=JSON.parse(j)}catch{a=[]};if(!Array.isArray(a))a=[a];process.exit(a.includes(v)?0:1)' "$VERSION" "$VERSIONS_JSON"; then
+              echo "::notice::${NAME}@${VERSION} is already on npm; skipping publish (re-run after a partial release)."
+            else
+              npm publish --access public --tag "$DIST_TAG"
+            fi
           elif grep -q "E404" "$ERRLOG"; then
+            # The package has never been published before — publish the first version.
             npm publish --access public --tag "$DIST_TAG"
           else
             echo "::error::Could not determine whether ${NAME}@${VERSION} is published; the npm registry query failed:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release & Publish
+
+# Publishes to npm (via OIDC trusted publishing) and creates a GitHub Release
+# with the built dist artifacts attached. Triggered by pushing a version tag.
+#
+#   npm version patch   # bumps package.json + creates the git tag
+#   git push --follow-tags
+#
+# One-time setup is required on npmjs.com — see RELEASING.md.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+# Never run two releases for the same ref at once.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # create the GitHub Release and upload build assets
+  id-token: write # mint the OIDC token for npm trusted publishing
+
+jobs:
+  release:
+    name: Build, publish to npm, and create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        # generated/ is committed, so the spec/ submodule is not needed to build.
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22' # resolves to >= 22.14.0, required for trusted publishing
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm to a trusted-publishing-capable version
+        run: npm install --global npm@latest # OIDC trusted publishing needs npm >= 11.5.1
+
+      - name: Verify the tag matches package.json version
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          echo "package.json: $PKG_VERSION | tag: $TAG_VERSION"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Tag '$GITHUB_REF_NAME' does not match package.json version '$PKG_VERSION'. Bump package.json or fix the tag."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build dist
+        run: npm run build
+        # .npmrc sets ignore-scripts=true, so prepublishOnly/prepare won't auto-build —
+        # we build explicitly here before packaging and publishing.
+
+      - name: Test
+        run: npm test
+
+      - name: Package dist build artifacts
+        run: |
+          NAME="cloudglue-cloudglue-js-${GITHUB_REF_NAME}"
+          # The npm-publishable tarball — exactly what gets published to the registry.
+          npm pack
+          # Convenience archives of the compiled output for the GitHub Release.
+          tar -czf "${NAME}-dist.tar.gz" dist docs README.md LICENSE.md package.json
+          zip -qr "${NAME}-dist.zip" dist docs README.md LICENSE.md package.json
+          ls -lh *.tgz "${NAME}-dist.tar.gz" "${NAME}-dist.zip"
+
+      - name: Publish to npm via OIDC trusted publishing
+        run: npm publish --access public
+        # No NODE_AUTH_TOKEN required: with a Trusted Publisher configured on npmjs.com,
+        # npm exchanges the GitHub OIDC token automatically and attaches provenance.
+
+      - name: Create GitHub Release with build artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            *.tgz
+            *-dist.tar.gz
+            *-dist.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,9 @@ jobs:
 
       - name: Build dist
         run: npm run build
-        # .npmrc sets ignore-scripts=true, so prepublishOnly/prepare won't auto-build —
-        # we build explicitly here before packaging and publishing.
+        # Build explicitly so dist/ is fresh before packaging and publishing — don't rely on
+        # npm's prepare/prepublishOnly lifecycle scripts, whose behavior here depends on the
+        # repo's .npmrc ignore-scripts setting and varies by npm version.
 
       - name: Test
         run: npm test

--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ This will:
 1. Clean the previous build
 2. Compile TypeScript files
 
+### Releasing
+
+Publishing to npm is automated via GitHub Actions using OIDC trusted publishing.
+Push a version tag and the workflow builds, publishes, and creates a GitHub
+Release with the build artifacts attached:
+
+```bash
+npm version patch     # bumps package.json and creates the git tag
+git push --follow-tags
+```
+
+See [RELEASING.md](RELEASING.md) for the full process and one-time npm setup.
+
 ## Contact
 
 * [Open an Issue](https://github.com/cloudglue/cloudglue-js/issues/new)

--- a/README.md
+++ b/README.md
@@ -110,16 +110,10 @@ This will:
 
 ### Releasing
 
-Publishing to npm is automated via GitHub Actions using OIDC trusted publishing.
-Push a version tag and the workflow builds, publishes, and creates a GitHub
-Release with the build artifacts attached:
-
-```bash
-npm version patch     # bumps package.json and creates the git tag
-git push --follow-tags
-```
-
-See [RELEASING.md](RELEASING.md) for the full process and one-time npm setup.
+Publishing to npm is automated: pushing a `v*.*.*` tag triggers a GitHub Actions
+workflow that builds, publishes via OIDC trusted publishing, and creates a GitHub
+Release with the build artifacts attached. See **[RELEASING.md](RELEASING.md)** for
+the exact commands, the one-time npm Trusted Publisher setup, and troubleshooting.
 
 ## Contact
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,81 @@
+# Releasing
+
+Releases are automated by [`.github/workflows/release.yml`](.github/workflows/release.yml).
+Pushing a version tag (`v*.*.*`) builds the package, publishes it to npm using
+**OIDC trusted publishing** (no long-lived `NPM_TOKEN`), and creates a GitHub
+Release with the built artifacts attached.
+
+## One-time setup (npmjs.com)
+
+Trusted publishing must be enabled once per package on npm:
+
+1. Sign in to [npmjs.com](https://www.npmjs.com) as an account with publish rights
+   to `@cloudglue/cloudglue-js`.
+2. Go to the package page → **Settings** → **Trusted Publisher**.
+3. Choose **GitHub Actions** and fill in:
+   - **Organization or user:** `cloudglue`
+   - **Repository:** `cloudglue-js`
+   - **Workflow filename:** `release.yml`
+   - **Environment:** *(leave blank — the workflow does not use a GitHub Environment)*
+4. Save.
+
+That's it — no secret is stored in GitHub. The workflow already declares the
+required `id-token: write` permission so GitHub can mint the OIDC token npm
+exchanges at publish time.
+
+> First publish ever for a brand-new package name may need a one-time manual
+> `npm publish` to create the package before trusted publishing can be attached.
+> `@cloudglue/cloudglue-js` already exists, so this does not apply here.
+
+## Cutting a release
+
+From an up-to-date `main`:
+
+```bash
+# 1. Bump the version — this updates package.json and creates a matching git tag.
+npm version patch     # or: minor / major / 0.8.0
+
+# 2. Push the commit and the tag together.
+git push --follow-tags
+```
+
+Pushing the `v*.*.*` tag triggers the workflow, which:
+
+1. Checks out the repo (the committed `generated/` clients mean the `spec/`
+   submodule is **not** needed to build).
+2. Installs deps with `npm ci` and upgrades npm to a version that supports
+   trusted publishing (≥ 11.5.1).
+3. Verifies the tag matches `package.json` `version` (fails fast on a mismatch).
+4. Builds (`npm run build`) and runs tests (`npm test`).
+
+   > Note: `.npmrc` sets `ignore-scripts=true`, so `prepublishOnly`/`prepare`
+   > do **not** run automatically during `npm publish` — the workflow builds
+   > explicitly before publishing.
+5. Packages artifacts: the publishable `npm pack` tarball plus convenience
+   `*-dist.tar.gz` and `*-dist.zip` archives of the compiled output.
+6. Publishes to npm via OIDC (provenance is attached automatically).
+7. Creates a GitHub Release for the tag with auto-generated notes and all three
+   artifacts attached.
+
+## Manual / fallback publish
+
+If you ever need to publish from your machine (e.g. the workflow is unavailable):
+
+```bash
+npm ci
+npm run build
+npm publish --access public   # requires npm login / 2FA
+```
+
+## Troubleshooting
+
+- **`npm error need auth` / OIDC not used** — the Trusted Publisher on npmjs.com
+  doesn't match `cloudglue/cloudglue-js` + `release.yml` exactly, or the runner's
+  npm is older than 11.5.1. The workflow upgrades npm; double-check the npm config.
+- **Version mismatch failure** — the pushed tag (`vX.Y.Z`) must equal
+  `package.json` `version`. Use `npm version` so they stay in sync.
+- **Release created but npm publish skipped** — publish runs *before* the GitHub
+  Release step, so if a release appears, the publish succeeded. Check the
+  workflow logs for the publish step output.
+- **Hardening (optional)** — for a sensitive publish workflow you may want to pin
+  the actions to commit SHAs instead of `@v4`/`@v2`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -82,5 +82,9 @@ npm publish --access public   # requires npm login / 2FA
 - **Release created but npm publish skipped** — publish runs *before* the GitHub
   Release step, so if a release appears, the publish succeeded. Check the
   workflow logs for the publish step output.
+- **Re-running after a partial failure is safe** — if `npm publish` succeeded but
+  a later step failed, just re-run the workflow for the same tag. The publish step
+  detects the version is already on npm and continues, and the GitHub Release step
+  updates the existing release rather than failing. No need to bump the version.
 - **Hardening (optional)** — for a sensitive publish workflow you may want to pin
   the actions to commit SHAs instead of `@v4`/`@v2`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,7 +79,14 @@ If you ever need to publish from your machine (e.g. the workflow is unavailable)
 ```bash
 npm ci
 npm run build
-npm publish --access public   # requires npm login / 2FA
+npm publish --access public              # stable release; requires npm login / 2FA
+```
+
+For a **prerelease**, match the automated workflow and publish to the `next`
+dist-tag so it does not become the default `npm install`:
+
+```bash
+npm publish --access public --tag next   # e.g. version 0.8.0-rc.0
 ```
 
 ## Troubleshooting

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -100,9 +100,14 @@ npm publish --access public   # requires npm login / 2FA
   version is *already* on npm, where it is skipped on purpose (see below). So if a
   release appears, the version is genuinely on npm.
 - **Re-running after a partial failure is safe** — if `npm publish` succeeded but a
-  later step failed, just re-run the workflow for the same tag. The publish step sees
-  the version is already on npm and **skips** publishing (it does not try to publish
-  over it), and the GitHub Release step updates the existing release rather than
-  failing. No need to bump the version.
+  later step failed, just re-run the workflow for the **same tag on the same commit**.
+  The publish step sees the version is already on npm and **skips** publishing (it does
+  not try to publish over it), and the GitHub Release step updates the existing release
+  rather than failing. No need to bump the version.
+  > Caveat: this assumes the tag still points at the originally published commit. **Never
+  > move a published tag to a different commit while keeping the same version** — the
+  > publish would be skipped (npm keeps the old tarball) while the GitHub Release re-uploads
+  > artifacts built from the new commit, silently desyncing the two. To ship new code,
+  > always bump the version (`npm version`) and push a new tag.
 - **Hardening (optional)** — for a sensitive publish workflow you may want to pin
   the actions to commit SHAs instead of `@v4`/`@v2`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,9 +56,9 @@ Pushing the `v*.*.*` tag triggers the workflow, which:
 3. Verifies the tag matches `package.json` `version` (fails fast on a mismatch).
 4. Builds (`npm run build`) and runs tests (`npm test`).
 
-   > Note: `.npmrc` sets `ignore-scripts=true`, so `prepublishOnly`/`prepare`
-   > do **not** run automatically during `npm publish` — the workflow builds
-   > explicitly before publishing.
+   > Note: the workflow builds explicitly before packaging/publishing rather than
+   > relying on npm's `prepare`/`prepublishOnly` lifecycle scripts, whose behavior
+   > depends on the repo's `.npmrc` `ignore-scripts` setting and the npm version.
 5. Packages artifacts: the publishable `npm pack` tarball plus convenience
    `*-dist.tar.gz` and `*-dist.zip` archives of the compiled output.
 6. Publishes to npm via OIDC (provenance is attached automatically). Stable

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,12 +79,15 @@ npm publish --access public   # requires npm login / 2FA
   `setup-node` is fine on its own and is the npm-documented setup.
 - **Version mismatch failure** — the pushed tag (`vX.Y.Z`) must equal
   `package.json` `version`. Use `npm version` so they stay in sync.
-- **Release created but npm publish skipped** — publish runs *before* the GitHub
-  Release step, so if a release appears, the publish succeeded. Check the
-  workflow logs for the publish step output.
-- **Re-running after a partial failure is safe** — if `npm publish` succeeded but
-  a later step failed, just re-run the workflow for the same tag. The publish step
-  detects the version is already on npm and continues, and the GitHub Release step
-  updates the existing release rather than failing. No need to bump the version.
+- **Did the publish actually happen?** — the publish step runs *before* the GitHub
+  Release step and never swallows a publish error: a real failure (auth/OIDC/network)
+  fails the job and no release is created. The only non-fatal case is when the exact
+  version is *already* on npm, where it is skipped on purpose (see below). So if a
+  release appears, the version is genuinely on npm.
+- **Re-running after a partial failure is safe** — if `npm publish` succeeded but a
+  later step failed, just re-run the workflow for the same tag. The publish step sees
+  the version is already on npm and **skips** publishing (it does not try to publish
+  over it), and the GitHub Release step updates the existing release rather than
+  failing. No need to bump the version.
 - **Hardening (optional)** — for a sensitive publish workflow you may want to pin
   the actions to commit SHAs instead of `@v4`/`@v2`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,6 +39,14 @@ npm version patch     # or: minor / major / 0.8.0
 git push --follow-tags
 ```
 
+For a prerelease, use a version with a hyphen — it publishes to the `next`
+dist-tag instead of `latest`:
+
+```bash
+npm version prerelease --preid rc   # e.g. 0.8.0-rc.0
+git push --follow-tags
+```
+
 Pushing the `v*.*.*` tag triggers the workflow, which:
 
 1. Checks out the repo (the committed `generated/` clients mean the `spec/`
@@ -53,9 +61,16 @@ Pushing the `v*.*.*` tag triggers the workflow, which:
    > explicitly before publishing.
 5. Packages artifacts: the publishable `npm pack` tarball plus convenience
    `*-dist.tar.gz` and `*-dist.zip` archives of the compiled output.
-6. Publishes to npm via OIDC (provenance is attached automatically).
+6. Publishes to npm via OIDC (provenance is attached automatically). Stable
+   versions go to the `latest` dist-tag; **prereleases** (a version with a
+   hyphen, e.g. `0.8.0-rc.1`) are published to the `next` tag instead, so they
+   never become the default `npm install`.
 7. Creates a GitHub Release for the tag with auto-generated notes and all three
    artifacts attached.
+
+> CI installs with `npm ci` against `package-lock.json`. If you change
+> dependencies, keep `package-lock.json` in sync (run `npm install` and commit
+> it) — a stale lockfile makes the release job fail at `npm ci`.
 
 ## Manual / fallback publish
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,6 +72,11 @@ npm publish --access public   # requires npm login / 2FA
 - **`npm error need auth` / OIDC not used** — the Trusted Publisher on npmjs.com
   doesn't match `cloudglue/cloudglue-js` + `release.yml` exactly, or the runner's
   npm is older than 11.5.1. The workflow upgrades npm; double-check the npm config.
+- **Publish uses token auth instead of OIDC** — never set `NODE_AUTH_TOKEN` for the
+  publish step (no `env:` block, no `${{ secrets.* }}` that could be empty). Any
+  value — including an empty string from a missing secret — disables OIDC and forces
+  token auth. The workflow intentionally leaves it unset; `registry-url` on
+  `setup-node` is fine on its own and is the npm-documented setup.
 - **Version mismatch failure** — the pushed tag (`vX.Y.Z`) must equal
   `package.json` `version`. Use `npm version` so they stay in sync.
 - **Release created but npm publish skipped** — publish runs *before* the GitHub


### PR DESCRIPTION
## What

Adds an automated release pipeline triggered by pushing a `v*.*.*` tag.

`.github/workflows/release.yml`:
1. Checks out (no `spec/` submodule needed — `generated/` is committed)
2. Sets up Node 22 + npm registry, upgrades npm to ≥ 11.5.1 (required for OIDC)
3. **Verifies the tag matches `package.json` version** (fails fast on mismatch)
4. `npm ci` → `npm run build` → `npm test`
5. Packages artifacts: publishable `npm pack` `.tgz` + `*-dist.tar.gz` + `*-dist.zip`
6. **Publishes to npm via OIDC trusted publishing** (no `NPM_TOKEN`; provenance attached automatically)
7. **Creates a GitHub Release** with auto-generated notes + all three artifacts attached

Also adds `RELEASING.md` (full process, one-time npm setup, troubleshooting) and links it from the README Development section.

## ⚠️ Required manual step before first release

OIDC needs a **Trusted Publisher** registered on npmjs.com (cannot be done in code):

- npmjs.com → `@cloudglue/cloudglue-js` → **Settings → Trusted Publisher** → **GitHub Actions**
  - Organization/user: `cloudglue`
  - Repository: `cloudglue-js`
  - Workflow filename: `release.yml`
  - Environment: *(blank)*

Until saved, the publish step fails with an auth error.

## Notes
- Build is run explicitly because `.npmrc` has `ignore-scripts=true` (suppresses `prepublishOnly`/`prepare`).
- Actions pinned to major tags for readability; SHA-pinning noted as optional hardening in RELEASING.md.

## How to release after merge
```bash
npm version patch
git push --follow-tags
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the only automated path to npm and GitHub Releases; misconfiguration (OIDC, tag/version mismatch, or moving a published tag) could block or desync releases, though safeguards limit duplicate publishes.
> 
> **Overview**
> Adds **automated releases** on push of `v*.*.*` tags via new `release.yml`: verify tag matches `package.json`, `npm ci` / build / test, package artifacts (`npm pack` plus dist tar/zip), **publish to npm with OIDC** (no `NPM_TOKEN`; prereleases use the `next` dist-tag), then create a **GitHub Release** with those files attached.
> 
> The publish step **skips** when that version is already on the registry so partial failures can be re-run safely, and fails loudly on registry lookup errors. Checkout uses `persist-credentials: false`; publish must not set `NODE_AUTH_TOKEN`.
> 
> **`RELEASING.md`** documents Trusted Publisher setup, release commands, manual fallback, and troubleshooting; **README** links to it under Development.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee8a96f11b7d59e3532bea58856f9d67ee664523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Local verification

A tag-triggered publish can only fully run on a GitHub runner (OIDC + real `npm publish`), but everything the workflow does **up to the publish call** was executed locally on this branch. All checks pass.

| # | What | How | Result |
|---|------|-----|--------|
| 1 | Workflow YAML valid | parsed `release.yml` | ✅ 10 steps, trigger `v*.*.*` |
| 2 | Shell syntax of every `run:` step | `bash -n` on each | ✅ all 7 pass |
| 3 | Build | `npm run build` (tsc + version bake) | ✅ compiles; `__SDK_VERSION__` → `0.7.18` in built `client.js` |
| 4 | Tests | `npm test` | ✅ **106/106 pass**, 0 fail |
| 5 | `npm ci` precondition | `npm ci --dry-run` | ✅ `package-lock.json` in sync |
| 6 | Tag↔version guard | simulated verify step | ✅ `v0.7.18`→pass; `v0.8.0`/`v0.7.18-rc.1`→fail (mismatch) |
| 7 | dist-tag selection | simulated `case` logic | ✅ stable→`latest`; `-rc.1`/`-beta.3`→`next` |
| 8 | GitHub prerelease flag | `contains(ref,'-')` equiv | ✅ `v0.8.0`→false; `v0.8.0-rc.1`→true |
| 9 | Publish-decision branches | simulated all paths against the live registry | ✅ exists→skip · fresh→publish · brand-new(E404)→publish · network-error→fail-loud · single-version JSON-string→skip |
| 10 | Packaging | ran `npm pack` + `tar` + `zip` | ✅ 3 artifacts produced; npm tgz = 174K/106 files incl. `dist/`+`docs/`; dist archives contain `dist docs README.md LICENSE.md package.json` |

**Not testable locally** (needs the GitHub Actions runner): OIDC trusted publishing handshake, the real `npm publish`, GitHub Release creation, and the `checkout`/`setup-node` actions. These depend on the one-time npm **Trusted Publisher** setup in `RELEASING.md`.

**Surfaced by this testing & fixed:** `npm pack` still runs the `prepare` script despite `.npmrc` `ignore-scripts=true`, contradicting an inline comment — corrected the comment in `release.yml` + `RELEASING.md` (behavior is still correct: the explicit Build step guarantees a fresh `dist/` regardless).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated, tag-triggered release process that builds and packages release artifacts, then creates GitHub Releases.
  * Supports stable releases (published under a `latest` dist-tag) and prereleases (published under a separate channel), using OIDC-based trusted publishing.
  * Includes safeguards for tag/version matching and safe re-runs to avoid republishing an already published version.
* **Documentation**
  * Expanded release/development documentation with step-by-step stable and prerelease publishing instructions plus OIDC/troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
