### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the TypeScript SDK for the hosted CloudGlue API (`https://api.cloudglue.dev/v1`). There is no local backend to run — the SDK is a client library.
+
+- Package manager: **npm** (`package-lock.json` is committed). `.npmrc` sets `ignore-scripts=true`. Dependencies are installed automatically by the environment update script.
+- Build/test/run commands are documented in `README.md` and `CLAUDE.md`. Common ones: `npm run build`, `npm run test` (node:test via `tsx`), `npm run watch`.
+- The generated Zodios clients in `generated/` are **committed**, so `npm run generate` and the `spec/` git submodule (`make submodule-init`) are **not** required to build or test. Only run `npm run generate` when intentionally regenerating from an updated spec.
+- Tests are pure unit tests (URL classification, mocked file API, connector grammar). They run **fully offline** and need no `CLOUDGLUE_API_KEY`.
+- No lint script is defined. `npx prettier --check "src/**/*.ts"` reports pre-existing style diffs and warns about an unknown `importOrder` option (a prettier plugin referenced in `.prettierrc.json` is not installed); these warnings are benign — do not reformat committed code as part of unrelated work.
+- Exercising real API calls (upload/describe/chat) requires a valid `CLOUDGLUE_API_KEY` (keys start with `cg-`) and network access to `api.cloudglue.dev`. Without a key, live calls fail fast with `CloudglueError: API key is not valid`, which confirms transport wiring works.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an `AGENTS.md` documenting how to set up and work in this repo from a Cursor Cloud agent environment.

Key durable notes captured:
- Uses **npm** (`package-lock.json` committed); `.npmrc` sets `ignore-scripts=true`.
- Generated Zodios clients in `generated/` are committed, so `npm run generate` and the `spec/` submodule are **not** required to build/test.
- `npm run build` and `npm run test` (106 unit tests, run fully offline, no API key).
- No lint script; `prettier --check` shows pre-existing diffs + a benign `importOrder` plugin warning.
- Live SDK calls need `CLOUDGLUE_API_KEY` + network to `api.cloudglue.dev`.

## Verification

- ✅ `npm install`
- ✅ `npm run build`
- ✅ `npm run test` — 106/106 passing
- ✅ Live call with a dummy key returns `CloudglueError: API key is not valid` (transport works end-to-end)

No source code changed; documentation only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e368ecfd-21ad-4222-8776-4e440e84705d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e368ecfd-21ad-4222-8776-4e440e84705d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

