### PR TITLE
feat: link_preview control for shareable assets (spec v0.7.10)

### DIFF
--- a/generated/Share.ts
+++ b/generated/Share.ts
@@ -9,6 +9,7 @@ type ShareableAsset = {
   description?: string | undefined;
   metadata?: {} | undefined;
   visibility?: ('public' | 'private') | undefined;
+  link_preview: 'none' | 'full';
   preview_url?: string | undefined;
   media_download_url?: string | undefined;
   media_download_expires_at?: (number | null) | undefined;
@@ -36,6 +37,7 @@ const ShareableAsset: z.ZodType<ShareableAsset> = z
     description: z.string().optional(),
     metadata: z.object({}).partial().strict().passthrough().optional(),
     visibility: z.enum(['public', 'private']).optional(),
+    link_preview: z.enum(['none', 'full']),
     preview_url: z.string().optional(),
     media_download_url: z.string().optional(),
     media_download_expires_at: z.number().nullish(),
@@ -66,6 +68,7 @@ const CreateShareableAssetRequest = z
     description: z.string().optional(),
     metadata: z.object({}).partial().strict().passthrough().optional(),
     visibility: z.enum(['public', 'private']).optional(),
+    link_preview: z.enum(['none', 'full']).optional(),
   })
   .strict()
   .passthrough();
@@ -74,6 +77,7 @@ const UpdateShareableAssetRequest = z
     title: z.string(),
     description: z.string(),
     metadata: z.object({}).partial().strict().passthrough(),
+    link_preview: z.enum(['none', 'full']),
   })
   .partial()
   .strict()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.19",
+      "version": "0.7.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/shareable.api.ts
+++ b/src/api/shareable.api.ts
@@ -15,6 +15,14 @@ export class EnhancedShareableApi {
     return this.api.listShareableAssets({ queries: data });
   }
 
+  /**
+   * Create a shareable asset for a file or file segment.
+   *
+   * `link_preview` controls rich Open Graph metadata for unfurl bots (Slack,
+   * iMessage, etc.) and only affects **private** shares: `'none'` (the API
+   * default) emits no preview metadata, `'full'` emits title, description,
+   * and thumbnail tags. Public shares always emit full metadata regardless.
+   */
   async createShareableAsset(data: {
     file_id: string;
     file_segment_id?: string;
@@ -22,6 +30,7 @@ export class EnhancedShareableApi {
     description?: string;
     metadata?: Record<string, unknown>;
     visibility?: 'public' | 'private';
+    link_preview?: 'none' | 'full';
   }) {
     return this.api.createShareableAsset(data);
   }
@@ -32,12 +41,20 @@ export class EnhancedShareableApi {
     });
   }
 
+  /**
+   * Update a shareable asset's presentation fields.
+   *
+   * `link_preview` toggles rich Open Graph metadata for unfurl bots on
+   * **private** shares (`'none'` or `'full'`); public shares always emit full
+   * metadata. Note `visibility` cannot be changed after creation.
+   */
   async updateShareableAsset(
     id: string,
     data: {
       title?: string;
       description?: string;
       metadata?: Record<string, unknown>;
+      link_preview?: 'none' | 'full';
     },
   ) {
     return this.api.updateShareableAsset(data, {


### PR DESCRIPTION
## Summary

Syncs the SDK to spec **v0.7.10** (cloudglue/cloudglue-api-spec#104) and bumps the package to **0.7.20**.

Adds `link_preview`, which lets callers opt private shares into rich Open Graph metadata for unfurl bots (Slack, iMessage, etc.). Values are `'none'` (API default — today's no-preview behavior) and `'full'` (title, description, thumbnail tags). Public shares always emit full metadata regardless.

### Generated
- `ShareableAsset` gains a **required** `link_preview: 'none' | 'full'`
- `CreateShareableAssetRequest` / `UpdateShareableAssetRequest` gain the optional field

### Wrapper (src/)
- `createShareableAsset` and `updateShareableAsset` take hand-written literal param types, so `link_preview` would otherwise be unreachable from the enhanced client — plumbed through both, with doc comments covering the private-vs-public semantics
- Response types flow automatically (`src/types.ts` re-exports via `z.infer`)

## Test plan

- [x] `npm run build` clean, `npm test` 106/106
- [x] Live API round-trip (creates private shares, deletes everything it creates — verified zero residue): create without the field defaults to `'none'`; create with `'full'` is honored; update toggles to `'full'` and back, persisting on read-back; list responses carry the field; an invalid enum value is rejected client-side by the Zod request schema — **7/7 checks passed**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive API surface plus a required response field that may require TypeScript consumers to handle `link_preview` on `ShareableAsset`; no auth or core runtime changes.
> 
> **Overview**
> Bumps **@cloudglue/cloudglue-js** to **0.7.20** and syncs generated share types to API spec **v0.7.10**.
> 
> Adds **`link_preview`** (`'none' | 'full'`) so callers can control rich Open Graph metadata for private share links (unfurl bots). Generated **`ShareableAsset`** now includes a **required** `link_preview`; create accepts it optionally and update can change it. The enhanced **`createShareableAsset`** / **`updateShareableAsset`** wrappers expose the field with JSDoc noting private-only behavior and that public shares always get full previews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d71c9b11e585e032efc0a91d607d701cc9a287b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->