### PR TITLE
feat: iconik connector, metadata collections, and source metadata search (spec v0.7.11)

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -520,4 +520,23 @@ for (const file of generatedFiles) {
     fs.writeFileSync(filePath, fileContent);
 }
 
+// TS7056: as of spec v0.7.11 Describe/Transcribe responses embed File, whose
+// source_metadata union spans seven connector variants — the structurally
+// inferred types of the big common.ts consts exceed what the compiler will
+// serialize into declaration files. Annotate them with their exported type
+// so downstream inference (tag-file endpoints, Zodios clients) references a
+// named type instead of re-expanding the structure.
+{
+    const bigCommonSchemas = ['SourceMetadata', 'File', 'Describe', 'DescribeList'];
+    const commonPath = path.join(generatedDir, 'common.ts');
+    let commonContent = fs.readFileSync(commonPath, 'utf8');
+    for (const name of bigCommonSchemas) {
+        commonContent = commonContent.replace(
+            new RegExp(`^export const ${name} = z`, 'm'),
+            `export const ${name}: z.ZodType<${name}> = z`
+        );
+    }
+    fs.writeFileSync(commonPath, commonContent);
+}
+
 console.log('Generation complete!'); 

--- a/generated/Collections.ts
+++ b/generated/Collections.ts
@@ -16,6 +16,7 @@ import { RecallSourceMetadata } from './common';
 import { GoogleDriveSourceMetadata } from './common';
 import { DropboxSourceMetadata } from './common';
 import { GongSourceMetadata } from './common';
+import { IconikSourceMetadata } from './common';
 import { DescribeOutput } from './common';
 import { DescribeOutputPart } from './common';
 import { SpeechOutputPart } from './common';
@@ -31,7 +32,8 @@ type Collection = {
     | 'media-descriptions'
     | 'entities'
     | 'rich-transcripts'
-    | 'face-analysis';
+    | 'face-analysis'
+    | 'metadata';
   extract_config?:
     | Partial<{
         prompt: string;
@@ -86,7 +88,8 @@ type NewCollection = {
     | 'media-descriptions'
     | 'entities'
     | 'rich-transcripts'
-    | 'face-analysis';
+    | 'face-analysis'
+    | 'metadata';
   name: string;
   description?: (string | null) | undefined;
   describe_config?:
@@ -196,6 +199,7 @@ type RichTranscript = {
         }>
       >
     | undefined;
+  file?: File | undefined;
 } & DescribeOutput;
 type CollectionRichTranscriptsList = {
   object: 'list';
@@ -216,6 +220,7 @@ type CollectionRichTranscriptsList = {
       >;
     }> &
       DescribeOutput;
+    file?: File | undefined;
   }>;
   total: number;
   limit: number;
@@ -242,6 +247,7 @@ type CollectionMediaDescriptionsList = {
       >;
     }> &
       DescribeOutput;
+    file?: File | undefined;
   }>;
   total: number;
   limit: number;
@@ -283,6 +289,7 @@ type MediaDescription = {
     | undefined;
   total_chapters?: number | undefined;
   total_shots?: number | undefined;
+  file?: File | undefined;
 } & DescribeOutput;
 type AddCollectionFile = (
   | {
@@ -295,6 +302,7 @@ type AddCollectionFile = (
   FileSegmentationConfig &
   Partial<{
     thumbnails_config: ThumbnailsConfig;
+    metadata: {};
   }>;
 
 const Collection: z.ZodType<Collection> = z
@@ -308,6 +316,7 @@ const Collection: z.ZodType<Collection> = z
       'entities',
       'rich-transcripts',
       'face-analysis',
+      'metadata',
     ]),
     extract_config: z
       .object({
@@ -398,6 +407,7 @@ const NewCollection: z.ZodType<NewCollection> = z
       'entities',
       'rich-transcripts',
       'face-analysis',
+      'metadata',
     ]),
     name: z.string(),
     description: z.string().nullish(),
@@ -487,7 +497,10 @@ const AddCollectionFile: z.ZodType<AddCollectionFile> = z
   .and(FileSegmentationConfig)
   .and(
     z
-      .object({ thumbnails_config: ThumbnailsConfig })
+      .object({
+        thumbnails_config: ThumbnailsConfig,
+        metadata: z.object({}).partial().strict().passthrough(),
+      })
       .partial()
       .strict()
       .passthrough()
@@ -586,6 +599,7 @@ const MediaDescription: z.ZodType<MediaDescription> = z
       .optional(),
     total_chapters: z.number().int().gte(0).optional(),
     total_shots: z.number().int().gte(0).optional(),
+    file: File.optional(),
   })
   .strict()
   .passthrough()
@@ -612,6 +626,7 @@ const RichTranscript: z.ZodType<RichTranscript> = z
           .passthrough()
       )
       .optional(),
+    file: File.optional(),
   })
   .strict()
   .passthrough()
@@ -647,6 +662,7 @@ const CollectionRichTranscriptsList: z.ZodType<CollectionRichTranscriptsList> =
               .strict()
               .passthrough()
               .and(DescribeOutput),
+            file: File.optional(),
           })
           .strict()
           .passthrough()
@@ -690,6 +706,7 @@ const CollectionMediaDescriptionsList: z.ZodType<CollectionMediaDescriptionsList
               .strict()
               .passthrough()
               .and(DescribeOutput),
+            file: File.optional(),
           })
           .strict()
           .passthrough()
@@ -930,6 +947,7 @@ const endpoints = makeApi([
             'entities',
             'rich-transcripts',
             'face-analysis',
+            'metadata',
           ])
           .optional(),
       },
@@ -1300,6 +1318,11 @@ const endpoints = makeApi([
         type: 'Query',
         schema: z.boolean().optional(),
       },
+      {
+        name: 'include_metadata',
+        type: 'Query',
+        schema: z.boolean().optional(),
+      },
     ],
     response: RichTranscript,
     errors: [
@@ -1446,6 +1469,11 @@ const endpoints = makeApi([
           )
           .optional(),
       },
+      {
+        name: 'include_metadata',
+        type: 'Query',
+        schema: z.boolean().optional(),
+      },
     ],
     response: CollectionRichTranscriptsList,
     errors: [
@@ -1529,6 +1557,11 @@ const endpoints = makeApi([
             ])
           )
           .optional(),
+      },
+      {
+        name: 'include_metadata',
+        type: 'Query',
+        schema: z.boolean().optional(),
       },
     ],
     response: CollectionMediaDescriptionsList,
@@ -1616,6 +1649,11 @@ const endpoints = makeApi([
       },
       {
         name: 'include_shots',
+        type: 'Query',
+        schema: z.boolean().optional(),
+      },
+      {
+        name: 'include_metadata',
         type: 'Query',
         schema: z.boolean().optional(),
       },

--- a/generated/Data_Connectors.ts
+++ b/generated/Data_Connectors.ts
@@ -9,6 +9,7 @@ import { RecallSourceMetadata } from './common';
 import { GoogleDriveSourceMetadata } from './common';
 import { DropboxSourceMetadata } from './common';
 import { GongSourceMetadata } from './common';
+import { IconikSourceMetadata } from './common';
 
 type DataConnectorList = {
   object: 'list';
@@ -28,7 +29,8 @@ type DataConnector = {
     | 'gong'
     | 'recall'
     | 'gcs'
-    | 'grain';
+    | 'grain'
+    | 'iconik';
   created_at: number;
   updated_at: number;
   metadata: {};
@@ -75,6 +77,7 @@ const DataConnector: z.ZodType<DataConnector> = z
       'recall',
       'gcs',
       'grain',
+      'iconik',
     ]),
     created_at: z.number().int(),
     updated_at: z.number().int(),

--- a/generated/Describe.ts
+++ b/generated/Describe.ts
@@ -6,6 +6,15 @@ import { DescribeOutput } from './common';
 import { DescribeOutputPart } from './common';
 import { SpeechOutputPart } from './common';
 import { WordTimestamp } from './common';
+import { File } from './common';
+import { SourceMetadata } from './common';
+import { GrainSourceMetadata } from './common';
+import { ZoomSourceMetadata } from './common';
+import { RecallSourceMetadata } from './common';
+import { GoogleDriveSourceMetadata } from './common';
+import { DropboxSourceMetadata } from './common';
+import { GongSourceMetadata } from './common';
+import { IconikSourceMetadata } from './common';
 import { ThumbnailsConfig } from './common';
 import { FileSegmentationConfig } from './common';
 import { SegmentationConfig } from './common';
@@ -33,6 +42,7 @@ type NewDescribe = {
         scope?: string | undefined;
       }>
     | undefined;
+  include_metadata?: boolean | undefined;
 } & FileSegmentationConfig;
 
 const NewDescribe: z.ZodType<NewDescribe> = z
@@ -56,6 +66,7 @@ const NewDescribe: z.ZodType<NewDescribe> = z
       )
       .max(50)
       .optional(),
+    include_metadata: z.boolean().optional(),
   })
   .strict()
   .passthrough()
@@ -176,6 +187,11 @@ const endpoints = makeApi([
           )
           .optional(),
       },
+      {
+        name: 'include_metadata',
+        type: 'Query',
+        schema: z.boolean().optional(),
+      },
     ],
     response: DescribeList,
     errors: [
@@ -261,6 +277,11 @@ const endpoints = makeApi([
       },
       {
         name: 'include_shots',
+        type: 'Query',
+        schema: z.boolean().optional(),
+      },
+      {
+        name: 'include_metadata',
         type: 'Query',
         schema: z.boolean().optional(),
       },

--- a/generated/Files.ts
+++ b/generated/Files.ts
@@ -1,7 +1,7 @@
 import { makeApi, Zodios, type ZodiosOptions } from '@zodios/core';
 import { z } from 'zod';
 import { File as CloudglueFile } from "./common";
-import { SourceMetadata, GrainSourceMetadata, ZoomSourceMetadata, RecallSourceMetadata, GoogleDriveSourceMetadata, DropboxSourceMetadata, GongSourceMetadata, Segmentation, SegmentationConfig, SegmentationUniformConfig, SegmentationShotDetectorConfig, SegmentationManualConfig, NarrativeConfig, KeyframeConfig, ThumbnailsConfig, Shot, Chapter, ThumbnailList, Thumbnail, ThumbnailType, ListVideoTagsResponse, PaginationResponse, VideoTag, FrameExtraction, FrameExtractionConfig, FrameExtractionUniformConfig, FrameExtractionThumbnailsConfig } from "./common";
+import { SourceMetadata, GrainSourceMetadata, ZoomSourceMetadata, RecallSourceMetadata, GoogleDriveSourceMetadata, DropboxSourceMetadata, GongSourceMetadata, IconikSourceMetadata, Segmentation, SegmentationConfig, SegmentationUniformConfig, SegmentationShotDetectorConfig, SegmentationManualConfig, NarrativeConfig, KeyframeConfig, ThumbnailsConfig, Shot, Chapter, ThumbnailList, Thumbnail, ThumbnailType, ListVideoTagsResponse, PaginationResponse, VideoTag, FrameExtraction, FrameExtractionConfig, FrameExtractionUniformConfig, FrameExtractionThumbnailsConfig } from "./common";
 
 type FileList = {
   object: 'list';
@@ -557,6 +557,33 @@ const endpoints = makeApi([
       {
         status: 400,
         description: `Invalid request or malformed file update parameters`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'post',
+    path: '/files/:file_id/sync',
+    alias: 'syncFileSourceMetadata',
+    description: `Re-fetches the file&#x27;s source_metadata live from its data connector (google-drive, dropbox, zoom, gong, recall, grain, or iconik) and updates the stored value. If the file belongs to any metadata collections, their search documents are re-indexed with the refreshed metadata. Works for both metadata-only files and fully ingested connector files. Free — no media is downloaded or processed.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'file_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: CloudglueFile,
+    errors: [
+      {
+        status: 400,
+        description: `File has no connector URI, the source does not support metadata lookup, or the account has no connector of that type`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 404,
+        description: `File not found`,
         schema: z.object({ error: z.string() }).strict().passthrough(),
       },
     ],

--- a/generated/Search.ts
+++ b/generated/Search.ts
@@ -44,6 +44,7 @@ type SearchModalities = Array<
   | 'ocr_lexical'
   | 'tag_semantic'
   | 'tag_lexical'
+  | 'doc_lexical'
 >;
 type FileSearchResult = {
   type: 'file';
@@ -170,6 +171,7 @@ const SearchModalities = z.array(
     'ocr_lexical',
     'tag_semantic',
     'tag_lexical',
+    'doc_lexical',
   ])
 );
 const SearchRequest: z.ZodType<SearchRequest> = z

--- a/generated/Segmentations.ts
+++ b/generated/Segmentations.ts
@@ -20,6 +20,15 @@ import { DescribeOutput } from './common';
 import { DescribeOutputPart } from './common';
 import { SpeechOutputPart } from './common';
 import { WordTimestamp } from './common';
+import { File } from './common';
+import { SourceMetadata } from './common';
+import { GrainSourceMetadata } from './common';
+import { ZoomSourceMetadata } from './common';
+import { RecallSourceMetadata } from './common';
+import { GoogleDriveSourceMetadata } from './common';
+import { DropboxSourceMetadata } from './common';
+import { GongSourceMetadata } from './common';
+import { IconikSourceMetadata } from './common';
 
 const endpoints = makeApi([
   {
@@ -164,6 +173,11 @@ const endpoints = makeApi([
         name: 'offset',
         type: 'Query',
         schema: z.number().int().gte(0).optional(),
+      },
+      {
+        name: 'include_metadata',
+        type: 'Query',
+        schema: z.boolean().optional(),
       },
     ],
     response: DescribeList,

--- a/generated/Transcribe.ts
+++ b/generated/Transcribe.ts
@@ -5,6 +5,15 @@ import { DescribeOutput } from './common';
 import { DescribeOutputPart } from './common';
 import { SpeechOutputPart } from './common';
 import { WordTimestamp } from './common';
+import { File } from './common';
+import { SourceMetadata } from './common';
+import { GrainSourceMetadata } from './common';
+import { ZoomSourceMetadata } from './common';
+import { RecallSourceMetadata } from './common';
+import { GoogleDriveSourceMetadata } from './common';
+import { DropboxSourceMetadata } from './common';
+import { GongSourceMetadata } from './common';
+import { IconikSourceMetadata } from './common';
 import { ThumbnailsConfig } from './common';
 import { FileSegmentationConfig } from './common';
 import { SegmentationConfig } from './common';
@@ -44,6 +53,7 @@ type Transcribe = {
         DescribeOutput)
     | undefined;
   error?: string | undefined;
+  file?: File | undefined;
 };
 type NewTranscribe = {
   url: string;
@@ -53,6 +63,7 @@ type NewTranscribe = {
   enable_scene_text?: boolean | undefined;
   enable_audio_description?: boolean | undefined;
   thumbnails_config?: ThumbnailsConfig | undefined;
+  include_metadata?: boolean | undefined;
 } & FileSegmentationConfig;
 type TranscribeList = {
   object: 'list';
@@ -108,6 +119,7 @@ const Transcribe: z.ZodType<Transcribe> = z
       .and(DescribeOutput)
       .optional(),
     error: z.string().optional(),
+    file: File.optional(),
   })
   .strict()
   .passthrough();
@@ -120,6 +132,7 @@ const NewTranscribe: z.ZodType<NewTranscribe> = z
     enable_scene_text: z.boolean().optional(),
     enable_audio_description: z.boolean().optional(),
     thumbnails_config: ThumbnailsConfig.optional(),
+    include_metadata: z.boolean().optional(),
   })
   .strict()
   .passthrough()
@@ -231,6 +244,11 @@ Note: For most use cases, you should use the &#x60;/describe&#x60; endpoint inst
         type: 'Query',
         schema: z.enum(['json', 'markdown']).optional(),
       },
+      {
+        name: 'include_metadata',
+        type: 'Query',
+        schema: z.boolean().optional(),
+      },
     ],
     response: TranscribeList,
     errors: [
@@ -262,6 +280,11 @@ Note: For most use cases, you should use the &#x60;/describe&#x60; endpoint inst
         name: 'response_format',
         type: 'Query',
         schema: z.enum(['json', 'markdown']).optional(),
+      },
+      {
+        name: 'include_metadata',
+        type: 'Query',
+        schema: z.boolean().optional(),
       },
     ],
     response: Transcribe,

--- a/generated/common.ts
+++ b/generated/common.ts
@@ -20,6 +20,7 @@ export type SearchFilter = Partial<{
         path: 'bytes' | 'filename' | 'uri' | 'created_at' | 'id';
       }>
   >;
+  source_metadata: Array<SearchFilterCriteria>;
 }>;
 export type SearchFilterCriteria = {
   path: string;
@@ -151,6 +152,7 @@ export type File = {
         | 'gcs'
         | 'grain'
         | 'loom'
+        | 'iconik'
       )
     | null
     | undefined;
@@ -162,7 +164,8 @@ export type SourceMetadata =
   | RecallSourceMetadata
   | GoogleDriveSourceMetadata
   | DropboxSourceMetadata
-  | GongSourceMetadata;
+  | GongSourceMetadata
+  | IconikSourceMetadata;
 export type GrainSourceMetadata = {
   source_type: 'grain';
   grain_recording_id: string;
@@ -404,6 +407,20 @@ export type GongSourceMetadata = {
   brief?: (string | null) | undefined;
   key_points?: (Array<string> | null) | undefined;
 };
+export type IconikSourceMetadata = {
+  source_type: 'iconik';
+  iconik_asset_id: string;
+  title?: (string | null) | undefined;
+  media_type?: (string | null) | undefined;
+  date_created?: (string | null) | undefined;
+  date_modified?: (string | null) | undefined;
+  duration_ms?: (number | null) | undefined;
+  ingested_rendition?: ('proxy' | 'original' | null) | undefined;
+  iconik_url?: (string | null) | undefined;
+  external_id?: (string | null) | undefined;
+  created_by_user?: (string | null) | undefined;
+  iconik_metadata?: ({} | null) | undefined;
+};
 export type Describe = {
   job_id: string;
   status: 'pending' | 'processing' | 'completed' | 'failed' | 'not_applicable';
@@ -461,6 +478,7 @@ export type Describe = {
     | undefined;
   total_chapters?: number | undefined;
   total_shots?: number | undefined;
+  file?: File | undefined;
 };
 export type DescribeList = {
   object: 'list';
@@ -984,15 +1002,33 @@ export const GongSourceMetadata = z
   })
   .strict()
   .passthrough();
-export const SourceMetadata = z.discriminatedUnion('source_type', [
+export const IconikSourceMetadata = z
+  .object({
+    source_type: z.literal('iconik'),
+    iconik_asset_id: z.string(),
+    title: z.string().nullish(),
+    media_type: z.string().nullish(),
+    date_created: z.string().nullish(),
+    date_modified: z.string().nullish(),
+    duration_ms: z.number().nullish(),
+    ingested_rendition: z.enum(['proxy', 'original']).nullish(),
+    iconik_url: z.string().nullish(),
+    external_id: z.string().nullish(),
+    created_by_user: z.string().nullish(),
+    iconik_metadata: z.object({}).partial().strict().passthrough().nullish(),
+  })
+  .strict()
+  .passthrough();
+export const SourceMetadata: z.ZodType<SourceMetadata> = z.discriminatedUnion('source_type', [
   GrainSourceMetadata,
   ZoomSourceMetadata,
   RecallSourceMetadata,
   GoogleDriveSourceMetadata,
   DropboxSourceMetadata,
   GongSourceMetadata,
+  IconikSourceMetadata,
 ]);
-export const File = z
+export const File: z.ZodType<File> = z
   .object({
     id: z.string(),
     status: z.enum([
@@ -1051,6 +1087,7 @@ export const File = z
         'gcs',
         'grain',
         'loom',
+        'iconik',
       ])
       .optional(),
     source_metadata: SourceMetadata.nullish(),
@@ -1223,11 +1260,12 @@ export const SearchFilter = z
           .passthrough()
       )
     ),
+    source_metadata: z.array(SearchFilterCriteria),
   })
   .partial()
   .strict()
   .passthrough();
-export const Describe = z
+export const Describe: z.ZodType<Describe> = z
   .object({
     job_id: z.string(),
     status: z.enum([
@@ -1315,10 +1353,11 @@ export const Describe = z
       .optional(),
     total_chapters: z.number().int().gte(0).optional(),
     total_shots: z.number().int().gte(0).optional(),
+    file: File.optional(),
   })
   .strict()
   .passthrough();
-export const DescribeList = z
+export const DescribeList: z.ZodType<DescribeList> = z
   .object({
     object: z.literal('list'),
     data: z.array(Describe),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.20",
+      "version": "0.7.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.20",
+  "version": "0.7.21",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/collections.api.ts
+++ b/src/api/collections.api.ts
@@ -28,6 +28,8 @@ type ListCollectionEntitiesParams = AddedFilterParams &
 type ListCollectionMediaDescriptionsParams = {
   response_format?: 'json' | 'markdown';
   modalities?: Modalities[];
+  /** Include each file's `metadata` and `source_metadata` on the `file` object */
+  include_metadata?: boolean;
 } & AddedFilterParams &
   OrderParams &
   PaginationParams;
@@ -37,7 +39,8 @@ type ListCollectionParams = {
     | 'entities'
     | 'rich-transcripts'
     | 'media-descriptions'
-    | 'face-analysis';
+    | 'face-analysis'
+    | 'metadata';
   order?: 'name' | 'created_at';
 } & PaginationParams;
 
@@ -203,6 +206,8 @@ export class EnhancedCollectionsApi {
       end_time_seconds?: number;
       modalities?: Modalities[];
       include_word_timestamps?: boolean;
+      /** Include the file's `metadata` and `source_metadata` on the `file` object */
+      include_metadata?: boolean;
     } = {},
   ) {
     return this.api.getTranscripts({
@@ -242,6 +247,8 @@ export class EnhancedCollectionsApi {
       include_word_timestamps?: boolean;
       include_chapters?: boolean;
       include_shots?: boolean;
+      /** Include the file's `metadata` and `source_metadata` on the `file` object */
+      include_metadata?: boolean;
     } = {},
   ) {
     return this.api.getMediaDescriptions({

--- a/src/api/data-connectors.api.ts
+++ b/src/api/data-connectors.api.ts
@@ -19,8 +19,8 @@ export interface ListDataConnectorFilesParams {
   page_token?: string;
   /**
    * Start date filter (YYYY-MM-DD, inclusive UTC day bound). Supported by
-   * Grain, Zoom, Recall, Google Drive, Dropbox, and Gong (Zoom and Gong
-   * default to a 6-month lookback when omitted); ignored for S3/GCS.
+   * Grain, Zoom, Recall, Google Drive, Dropbox, Gong, and Iconik (Zoom and
+   * Gong default to a 6-month lookback when omitted); ignored for S3/GCS.
    */
   from?: string;
   /** End date filter (YYYY-MM-DD). Same per-connector support as `from`. */
@@ -35,8 +35,8 @@ export interface ListDataConnectorFilesParams {
   prefix?: string;
   /**
    * Case-insensitive title filter. Supported by Grain, Zoom, Google Drive,
-   * Dropbox, and Gong; ignored for Recall (no title available when listing)
-   * and S3/GCS.
+   * Dropbox, Gong, and Iconik (full-text title search); ignored for Recall
+   * (no title available when listing) and S3/GCS.
    */
   title_search?: string;
   /** Filter by team (Grain) */
@@ -81,9 +81,9 @@ export class EnhancedDataConnectorsApi {
   /**
    * Fetch source metadata for a connector URI directly from the upstream
    * source, without creating a Cloudglue file. Supported for Grain, Zoom,
-   * Recall, Google Drive, Dropbox, and Gong; S3/GCS return 501 (plain object
-   * stores have no richer metadata). Returns 502 when the upstream provider's
-   * response can't be validated.
+   * Recall, Google Drive, Dropbox, Gong, and Iconik; S3/GCS return 501
+   * (plain object stores have no richer metadata). Returns 502 when the
+   * upstream provider's response can't be validated.
    *
    * @param connectorId - The ID of the data connector
    * @param url - Connector URI to look up (must match the connector's type)
@@ -100,8 +100,8 @@ export class EnhancedDataConnectorsApi {
    * Materialize a connector URI (e.g. `grain://recording/<id>`) into a
    * Cloudglue file without starting a downstream job. Idempotent: syncing the
    * same URI returns the existing file. For Grain, Zoom, Recall, Google
-   * Drive, Dropbox, and Gong the file's `source_metadata` is populated from
-   * the provider.
+   * Drive, Dropbox, Gong, and Iconik the file's `source_metadata` is
+   * populated from the provider.
    *
    * Known https share links are rewritten client-side into connector URIs
    * (e.g. `drive.google.com/file/d/<id>` → `gdrive://file/<id>`), and some

--- a/src/api/describe.api.ts
+++ b/src/api/describe.api.ts
@@ -49,6 +49,8 @@ export class EnhancedDescribeApi {
       include_word_timestamps?: boolean;
       include_chapters?: boolean;
       include_shots?: boolean;
+      /** Include the file's `metadata` and `source_metadata` on the `file` object */
+      include_metadata?: boolean;
     } = {
       response_format: 'json',
     },
@@ -75,6 +77,8 @@ export class EnhancedDescribeApi {
       response_format?: 'json' | 'markdown';
       include_data?: boolean;
       modalities?: Modalities[];
+      /** Include each file's `metadata` and `source_metadata` on the `file` object */
+      include_metadata?: boolean;
     } = {},
   ) {
     return this.api.listDescribes({ queries: params });

--- a/src/api/files.api.ts
+++ b/src/api/files.api.ts
@@ -210,6 +210,23 @@ export class EnhancedFilesApi {
     return this.api.getFile({ params: { file_id: fileId } });
   }
 
+  /**
+   * Re-fetch a connector file's `source_metadata` live from its data
+   * connector (google-drive, dropbox, zoom, gong, recall, grain, or iconik)
+   * and update the stored value. If the file belongs to any metadata
+   * collections, their search documents are re-indexed with the refreshed
+   * metadata. Works for both metadata-only and fully ingested connector
+   * files. Free — no media is downloaded or processed.
+   *
+   * @param fileId - The ID of the connector-backed file to refresh
+   * @returns The file with refreshed `source_metadata`
+   */
+  async syncSourceMetadata(fileId: string) {
+    return this.api.syncFileSourceMetadata(undefined, {
+      params: { file_id: fileId },
+    });
+  }
+
   async deleteFile(fileId: string) {
     return this.api.deleteFile(undefined, {
       params: { file_id: fileId },

--- a/src/api/segmentations.api.ts
+++ b/src/api/segmentations.api.ts
@@ -64,6 +64,8 @@ export class EnhancedSegmentationsApi {
       response_format?: 'json' | 'markdown';
       limit?: number;
       offset?: number;
+      /** Include each file's `metadata` and `source_metadata` on the `file` object */
+      include_metadata?: boolean;
     } = {},
   ) {
     return this.api.listSegmentationDescribes({

--- a/src/api/transcribe.api.ts
+++ b/src/api/transcribe.api.ts
@@ -37,11 +37,16 @@ export class EnhancedTranscribeApi {
     jobId: string,
     options: {
       response_format?: 'json' | 'markdown';
+      /** Include the file's `metadata` and `source_metadata` on the `file` object */
+      include_metadata?: boolean;
     } = {},
   ) {
     return this.api.getTranscribe({
       params: { job_id: jobId },
-      queries: { response_format: options.response_format },
+      queries: {
+        response_format: options.response_format,
+        include_metadata: options.include_metadata,
+      },
     });
   }
 
@@ -62,6 +67,8 @@ export class EnhancedTranscribeApi {
       created_after?: string;
       url?: string;
       response_format?: 'json' | 'markdown';
+      /** Include each file's `metadata` and `source_metadata` on the `file` object */
+      include_metadata?: boolean;
     } = {},
   ) {
     return this.api.listTranscribes({ queries: params });

--- a/src/types.ts
+++ b/src/types.ts
@@ -446,7 +446,7 @@ export type DataConnectorFileList = z.infer<
  * Provider-populated source metadata attached to files synced through a data
  * connector (`file.source_metadata`) and returned by
  * `dataConnectors.getSourceMetadata()`. Discriminated union on `source_type`
- * covering all six metadata-bearing connectors.
+ * covering all seven metadata-bearing connectors.
  */
 export type {
   SourceMetadata,
@@ -456,6 +456,7 @@ export type {
   GoogleDriveSourceMetadata,
   DropboxSourceMetadata,
   GongSourceMetadata,
+  IconikSourceMetadata,
 } from '../generated/common';
 
 /**

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -26,7 +26,8 @@ export type VideoUrlSource =
   | 'gong'
   | 'recall'
   | 'gcs'
-  | 'grain';
+  | 'grain'
+  | 'iconik';
 
 export interface NormalizedVideoUrl {
   /** The URL to send to the API (rewritten when a known share-link form was recognized) */
@@ -66,6 +67,7 @@ export const CONNECTOR_SYNC_URI_GRAMMAR: Record<string, string> = {
   grain: 'grain://recording/<recordingId>',
   gong: 'gong://call/<callId>',
   recall: 'recall://recording/<recordingId>',
+  iconik: 'iconik://asset/<assetId>',
 };
 
 /**
@@ -126,6 +128,7 @@ export function classifyVideoUrl(url: string): VideoUrlSource | null {
   if (LOOM_SHARE_URL_REGEX.test(url)) return 'loom';
   if (url.startsWith('gong://call/')) return 'gong';
   if (url.startsWith('recall://recording/')) return 'recall';
+  if (url.startsWith('iconik://asset/')) return 'iconik';
   if (url.startsWith('gs://')) return 'gcs';
   if (url.startsWith('grain://recording/')) return 'grain';
   const parsed = tryParseUrl(url);

--- a/test/url-utils.test.ts
+++ b/test/url-utils.test.ts
@@ -31,6 +31,7 @@ describe('classifyVideoUrl', () => {
     ['gong://call/123456', 'gong'],
     ['recall://recording/abc-123', 'recall'],
     ['grain://recording/abc-123', 'grain'],
+    ['iconik://asset/abc-123', 'iconik'],
     ['https://example.com/video.mp4', 'http'],
     ['http://example.com/video.mp4', 'http'],
     // dropbox file share links resolve via a connector's OAuth (API 0.7.5)
@@ -325,6 +326,7 @@ describe('CONNECTOR_SYNC_URI_GRAMMAR', () => {
         'gong',
         'google-drive',
         'grain',
+        'iconik',
         'recall',
         's3',
         'zoom',


### PR DESCRIPTION
## Summary

Syncs the SDK to spec **v0.7.11** (cloudglue/cloudglue-api-spec#105) and bumps the package to **0.7.21**.

> **Branch note:** the local working checkout this started from was based 14 commits behind main (it predated the v0.7.9/v0.7.10 wrapper work and the fixed `generate.js`), so this branch was rebuilt from `origin/main` and the regen re-run with main's generator. The version is 0.7.21 (next after the released 0.7.20), not the 0.7.12 the stale base implied.

### Generated
- `IconikSourceMetadata`; the `SourceMetadata` discriminated union and the `DataConnector.type`/`File.source` enums now cover **iconik**
- New `syncFileSourceMetadata` endpoint (`POST /files/{file_id}/sync`)
- `include_metadata` on describe/transcribe get+list, collection media-description/rich-transcript listings, and segmentation describes; `Describe`/`Transcribe` responses gain a `file` object
- `SearchFilter.source_metadata` + the `doc_lexical` search modality
- `metadata` collection type

### generate.js — TS7056 fix
Describe/Transcribe responses now embed `File`, whose seven-variant `source_metadata` union pushed the structurally inferred types of the big `common.ts` consts past the compiler's declaration-emit limit (`error TS7056` in Segmentations/Files clients). Fixed at the root: `SourceMetadata`, `File`, `Describe`, and `DescribeList` consts are now annotated `z.ZodType<T>` (same pattern as the existing `ResponseKnowledgeBase` annotation), so downstream inference references named types.

### Wrapper (src/)
- `files.syncSourceMetadata(fileId)` — new endpoint, unreachable without a wrapper method
- `include_metadata` plumbed through the hand-written param literals in describe/transcribe/segmentations/collections (9 endpoints)
- `'metadata'` added to `ListCollectionParams.collection_type` (create flows automatically via `z.infer`)
- `IconikSourceMetadata` re-exported from `types.ts`
- `url-utils`: `iconik://asset/<id>` grammar + classification, with unit tests
- Data-connector filter/support docs updated for iconik

## Test plan

- [x] `npm run build` clean (TS7056 resolved), `npm test` **107/107**
- [x] Live battery — **14/14** (full evidence in `~/Downloads/cloudglue-v0.7.11-sdk-test-results.md`): iconik listing/per-file metadata/source-metadata narrowing/native title_search; metadata collection created + grain & iconik **URLs** indexed without processing (then deleted); `syncSourceMetadata` refreshes both providers; `doc_lexical` search with a `source_metadata.title` filter finds exactly the grain file and a negative filter excludes it; `include_metadata` toggles file metadata on describe get/list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large generated-client sync plus new search/collection behaviors; risk is mainly API contract drift and TypeScript emit fixes rather than runtime auth or payment logic.
> 
> **Overview**
> Bumps **@cloudglue/cloudglue-js** to **0.7.21** and regenerates clients from OpenAPI **v0.7.11**.
> 
> **Iconik & connector metadata:** Adds **`IconikSourceMetadata`** and **`iconik`** across data-connector types, file `source`, and the `SourceMetadata` union. **`url-utils`** recognizes **`iconik://asset/<id>`** (with tests).
> 
> **Metadata collections & search:** New **`metadata`** `collection_type`; **`AddCollectionFile`** can pass optional **`metadata`**. Search gains **`doc_lexical`** and **`SearchFilter.source_metadata`** for filtering on connector fields.
> 
> **API surface:** New **`POST /files/:file_id/sync`** (`syncFileSourceMetadata`) to refresh stored **`source_metadata`** and re-index metadata collections. **`include_metadata`** is wired on describe/transcribe (create + list/get), collection media-description/rich-transcript routes, and segmentation describes; related responses can include an optional embedded **`file`**.
> 
> **Build fix:** **`generate.js`** annotates large **`common.ts`** schemas (`SourceMetadata`, `File`, `Describe`, `DescribeList`) as **`z.ZodType<T>`** to avoid **TS7056** when responses embed `File`.
> 
> **Hand-written `src/`:** Exposes **`files.syncSourceMetadata`**, documents/plumbs **`include_metadata`**, extends collection listing for **`metadata`**, re-exports **`IconikSourceMetadata`**, and updates data-connector docs for Iconik.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f5f26a2c6d72f1e496ead2b340efd2f5fbb45f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->