### PR TITLE
feat: enable_metadata_mode for entity extraction (spec v0.7.12)

### DIFF
--- a/generated/Collections.ts
+++ b/generated/Collections.ts
@@ -41,6 +41,7 @@ type Collection = {
         enable_video_level_entities: boolean;
         enable_segment_level_entities: boolean;
         enable_transcript_mode: boolean;
+        enable_metadata_mode: boolean;
       }>
     | undefined;
   transcribe_config?:
@@ -108,6 +109,7 @@ type NewCollection = {
         enable_video_level_entities: boolean;
         enable_segment_level_entities: boolean;
         enable_transcript_mode: boolean;
+        enable_metadata_mode: boolean;
       }>
     | undefined;
   transcribe_config?:
@@ -325,6 +327,7 @@ const Collection: z.ZodType<Collection> = z
         enable_video_level_entities: z.boolean(),
         enable_segment_level_entities: z.boolean(),
         enable_transcript_mode: z.boolean(),
+        enable_metadata_mode: z.boolean(),
       })
       .partial()
       .strict()
@@ -430,6 +433,7 @@ const NewCollection: z.ZodType<NewCollection> = z
         enable_video_level_entities: z.boolean(),
         enable_segment_level_entities: z.boolean(),
         enable_transcript_mode: z.boolean(),
+        enable_metadata_mode: z.boolean(),
       })
       .partial()
       .strict()

--- a/generated/Extract.ts
+++ b/generated/Extract.ts
@@ -22,6 +22,7 @@ type Extract = {
         enable_video_level_entities: boolean;
         enable_segment_level_entities: boolean;
         enable_transcript_mode: boolean;
+        enable_metadata_mode: boolean;
       }>
     | undefined;
   segmentation_id?: string | undefined;
@@ -68,6 +69,7 @@ type NewExtract = {
   enable_video_level_entities?: boolean | undefined;
   enable_segment_level_entities?: boolean | undefined;
   enable_transcript_mode?: boolean | undefined;
+  enable_metadata_mode?: boolean | undefined;
   thumbnails_config?: ThumbnailsConfig | undefined;
   include_chapters?: boolean | undefined;
   include_shots?: boolean | undefined;
@@ -99,6 +101,7 @@ const Extract: z.ZodType<Extract> = z
         enable_video_level_entities: z.boolean(),
         enable_segment_level_entities: z.boolean(),
         enable_transcript_mode: z.boolean(),
+        enable_metadata_mode: z.boolean(),
       })
       .partial()
       .strict()
@@ -178,6 +181,7 @@ const NewExtract: z.ZodType<NewExtract> = z
     enable_video_level_entities: z.boolean().optional(),
     enable_segment_level_entities: z.boolean().optional(),
     enable_transcript_mode: z.boolean().optional(),
+    enable_metadata_mode: z.boolean().optional(),
     thumbnails_config: ThumbnailsConfig.optional(),
     include_chapters: z.boolean().optional(),
     include_shots: z.boolean().optional(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.21",
+      "version": "0.7.22",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",
@@ -924,9 +924,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -959,16 +959,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1234,9 +1234,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -1491,9 +1491,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Summary

Syncs the SDK to spec **v0.7.12** (cloudglue/cloudglue-api-spec#106) and bumps the package to **0.7.22**.

Adds `enable_metadata_mode` to extraction configs: entities are extracted from the file's **metadata document** (filename, file details, user metadata, connector source metadata) instead of the media content — file-level entities only, flat 1 credit per file, works on metadata-only files without ingesting media, mutually exclusive with `enable_transcript_mode`.

### Generated
- `NewExtract`, `Extract.extract_config`, and both entities-collection `extract_config` variants gain the flag

### Wrapper (src/)
- **No changes needed** — `createExtract` options and `NewCollectionParams.extract_config` are `z.infer` of the generated schemas, so the flag flows through the existing surface

## Test plan

- [x] `npm run build` clean, `npm test` 107/107
- [x] Live battery — **6/6** (evidence in `~/Downloads/cloudglue-v0.7.12-sdk-test-results.md`): metadata-mode extract on a **metadata-only** grain file completes with entities mirroring its connector source metadata (`{"title":"Amy / KDR","platform":"grain","participants":[...]}`, `segment_entities` empty); server rejects `enable_metadata_mode`+`enable_transcript_mode`; an entities collection with `extract_config.enable_metadata_mode` extracts the same from a connector URL. Job + collection deleted at cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only SDK sync with no hand-written API logic changes; behavior is delegated to the server (e.g. mutual exclusion with `enable_transcript_mode`).
> 
> **Overview**
> Syncs the client to API spec **v0.7.12** and releases **@cloudglue/cloudglue-js@0.7.22**.
> 
> Adds optional **`enable_metadata_mode`** on extraction: **`NewExtract`**, **`Extract.extract_config`**, and entities-collection **`extract_config`** (create + collection types) in the generated Zod/TS models. Callers can request entity extraction from the file **metadata document** (filename, user/connector metadata) instead of media; the flag is available on one-off extract jobs and entities collections without changes to `src/` because **`createExtract`** and collection params already **`z.infer`** the generated schemas.
> 
> The lockfile picks up minor transitive bumps (e.g. **axios** 1.17.0 → 1.18.1) alongside the version bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b7b0a85248bf781682a546a722d04057b314437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->