### PR TITLE
feat: Query API for SQL over extracted entities (spec v0.7.15)

### DIFF
--- a/generated/Data_Connectors.ts
+++ b/generated/Data_Connectors.ts
@@ -49,6 +49,7 @@ type DataConnectorFile = {
   mime_type: string | null;
   size_bytes: number | null;
   created_at: number | null;
+  thumbnail_url?: (string | null) | undefined;
   metadata: Partial<
     {
       folder_id: string;
@@ -104,6 +105,7 @@ const DataConnectorFile: z.ZodType<DataConnectorFile> = z
     mime_type: z.string().nullable(),
     size_bytes: z.number().int().nullable(),
     created_at: z.number().int().nullable(),
+    thumbnail_url: z.string().nullish(),
     metadata: z
       .object({ folder_id: z.string(), path: z.string(), prefix: z.string() })
       .partial()

--- a/generated/Files.ts
+++ b/generated/Files.ts
@@ -565,7 +565,7 @@ const endpoints = makeApi([
     method: 'post',
     path: '/files/:file_id/sync',
     alias: 'syncFileSourceMetadata',
-    description: `Re-fetches the file&#x27;s source_metadata live from its data connector (google-drive, dropbox, zoom, gong, recall, grain, or iconik) and updates the stored value. If the file belongs to any metadata collections, their search documents are re-indexed with the refreshed metadata. Works for both metadata-only files and fully ingested connector files. Free — no media is downloaded or processed.`,
+    description: `Re-fetches the file&#x27;s source_metadata live from its data connector (google-drive, dropbox, zoom, gong, recall, grain, or iconik) and updates the stored value. If the file belongs to any metadata collections, their search documents are re-indexed with the refreshed metadata. For iconik files without a thumbnail, the asset&#x27;s poster keyframe is also copied and set as the file&#x27;s thumbnail_url. Works for both metadata-only files and fully ingested connector files. Free — no media is downloaded or processed.`,
     requestFormat: 'json',
     parameters: [
       {

--- a/generated/Query.ts
+++ b/generated/Query.ts
@@ -1,0 +1,430 @@
+import { makeApi, Zodios, type ZodiosOptions } from '@zodios/core';
+import { z } from 'zod';
+
+type QueryResult = Partial<{
+  id: string;
+  object: 'query_result';
+  status: 'completed' | 'failed' | 'in_progress' | 'cancelled';
+  created_at: number;
+  collections: Array<string>;
+  sql: string | null;
+  columns: Array<
+    Partial<{
+      name: string;
+      type: string;
+    }>
+  > | null;
+  rows: Array<{}> | null;
+  row_count: number;
+  truncated: boolean;
+  dry_run: boolean;
+  usage: QueryUsage;
+  error: Partial<{
+    code: string;
+    message: string;
+  }> | null;
+  format: 'json' | 'csv' | 'jsonl' | null;
+  download_url: string | null;
+  download_expires_at: number | null;
+  output_bytes: number | null;
+}>;
+type QueryUsage = Partial<{
+  files_scanned: number;
+  entity_rows: number;
+  segment_entity_rows: number;
+  engine_ms: number;
+  total_ms: number;
+}>;
+type QueryListResponse = Partial<{
+  object: 'list';
+  data: Array<QueryListItem>;
+  total: number;
+  limit: number;
+  offset: number;
+}>;
+type QueryListItem = Partial<{
+  id: string;
+  object: 'query_result';
+  status: 'completed' | 'failed' | 'in_progress' | 'cancelled';
+  created_at: number;
+  collections: Array<string>;
+  sql: string | null;
+  row_count: number;
+  truncated: boolean;
+  usage: QueryUsage;
+  error: Partial<{
+    code: string;
+    message: string;
+  }> | null;
+}>;
+type QuerySchema = Partial<{
+  object: 'query_schema';
+  tables: Array<QuerySchemaTable>;
+  collections: Array<QuerySchemaCollection>;
+}>;
+type QuerySchemaTable = Partial<{
+  name: string;
+  description: string;
+  columns: Array<
+    Partial<{
+      name: string;
+      type: string;
+      description: string;
+    }>
+  >;
+}>;
+type QuerySchemaCollection = Partial<{
+  collection_id: string;
+  fields: Array<
+    Partial<{
+      name: string;
+      type: string;
+      level: 'file' | 'segment';
+    }>
+  >;
+  extract_schema: {} | null;
+  prompt: string | null;
+}>;
+
+const QueryUsage: z.ZodType<QueryUsage> = z
+  .object({
+    files_scanned: z.number().int(),
+    entity_rows: z.number().int(),
+    segment_entity_rows: z.number().int(),
+    engine_ms: z.number(),
+    total_ms: z.number(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const QueryResult: z.ZodType<QueryResult> = z
+  .object({
+    id: z.string().uuid(),
+    object: z.literal('query_result'),
+    status: z.enum(['completed', 'failed', 'in_progress', 'cancelled']),
+    created_at: z.number(),
+    collections: z.array(z.string().uuid()),
+    sql: z.string().nullable(),
+    columns: z
+      .array(
+        z
+          .object({ name: z.string(), type: z.string() })
+          .partial()
+          .strict()
+          .passthrough()
+      )
+      .nullable(),
+    rows: z.array(z.object({}).partial().strict().passthrough()).nullable(),
+    row_count: z.number().int(),
+    truncated: z.boolean(),
+    dry_run: z.boolean(),
+    usage: QueryUsage,
+    error: z
+      .object({ code: z.string(), message: z.string() })
+      .partial()
+      .strict()
+      .passthrough()
+      .nullable(),
+    format: z.enum(['json', 'csv', 'jsonl']).nullable(),
+    download_url: z.string().nullable(),
+    download_expires_at: z.number().nullable(),
+    output_bytes: z.number().int().nullable(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const QueryListItem: z.ZodType<QueryListItem> = z
+  .object({
+    id: z.string().uuid(),
+    object: z.literal('query_result'),
+    status: z.enum(['completed', 'failed', 'in_progress', 'cancelled']),
+    created_at: z.number(),
+    collections: z.array(z.string().uuid()),
+    sql: z.string().nullable(),
+    row_count: z.number().int(),
+    truncated: z.boolean(),
+    usage: QueryUsage,
+    error: z
+      .object({ code: z.string(), message: z.string() })
+      .partial()
+      .strict()
+      .passthrough()
+      .nullable(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const QueryListResponse: z.ZodType<QueryListResponse> = z
+  .object({
+    object: z.literal('list'),
+    data: z.array(QueryListItem),
+    total: z.number().int(),
+    limit: z.number().int(),
+    offset: z.number().int(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const QuerySchemaTable: z.ZodType<QuerySchemaTable> = z
+  .object({
+    name: z.string(),
+    description: z.string(),
+    columns: z.array(
+      z
+        .object({ name: z.string(), type: z.string(), description: z.string() })
+        .partial()
+        .strict()
+        .passthrough()
+    ),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const QuerySchemaCollection: z.ZodType<QuerySchemaCollection> = z
+  .object({
+    collection_id: z.string().uuid(),
+    fields: z.array(
+      z
+        .object({
+          name: z.string(),
+          type: z.string(),
+          level: z.enum(['file', 'segment']),
+        })
+        .partial()
+        .strict()
+        .passthrough()
+    ),
+    extract_schema: z.object({}).partial().strict().passthrough().nullable(),
+    prompt: z.string().nullable(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const QuerySchema: z.ZodType<QuerySchema> = z
+  .object({
+    object: z.literal('query_schema'),
+    tables: z.array(QuerySchemaTable),
+    collections: z.array(QuerySchemaCollection),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const RunQueryRequest = z
+  .object({
+    collections: z.array(z.string().uuid()).min(1).max(20),
+    sql: z.string().min(1).max(20000).optional(),
+    query: z.string().min(1).max(2000).optional(),
+    format: z.enum(['json', 'csv', 'jsonl']).optional(),
+    max_rows: z.number().int().gte(1).lte(10000).optional(),
+    background: z.boolean().optional(),
+    dry_run: z.boolean().optional(),
+  })
+  .strict()
+  .passthrough();
+
+export const schemas = {
+  QueryUsage,
+  QueryResult,
+  QueryListItem,
+  QueryListResponse,
+  QuerySchemaTable,
+  QuerySchemaCollection,
+  QuerySchema,
+  RunQueryRequest,
+};
+
+const endpoints = makeApi([
+  {
+    method: 'post',
+    path: '/query',
+    alias: 'runQuery',
+    description: `Run a synchronous read-only SQL query over the structured data extracted from one or more collections. Queries execute against three virtual tables — files, entities, and segment_entities — built from each file&#x27;s most recent completed extraction.
+
+Each query costs 2 credits. Results are returned inline and stored, so completed runs can be re-fetched via GET /query/{id}. Use GET /query/schema to discover the queryable tables and per-collection fields.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'body',
+        description: `Query execution parameters`,
+        type: 'Body',
+        schema: RunQueryRequest,
+      },
+    ],
+    response: QueryResult,
+    errors: [
+      {
+        status: 400,
+        description: `Invalid request parameters or rejected SQL (multiple statements, a non-SELECT statement, SQL that could not be parsed, or a face-analysis collection in scope)`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 402,
+        description: `Insufficient credit balance`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 404,
+        description: `One or more collections not found`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 408,
+        description: `Query exceeded the execution time limit`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 409,
+        description: `The selected collections exceed the maximum queryable dataset size`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 422,
+        description: `A natural-language query could not be compiled into valid SQL — refine the question or send sql directly`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 429,
+        description: `Too many concurrent queries, or the per-minute rate limit was exceeded`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 500,
+        description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'get',
+    path: '/query',
+    alias: 'listQueries',
+    description: `List all query runs with pagination and filtering options. List items omit the columns and rows payloads — fetch an individual run via GET /query/{id} for the full result.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'limit',
+        type: 'Query',
+        schema: z.number().int().gte(1).lte(100).optional(),
+      },
+      {
+        name: 'offset',
+        type: 'Query',
+        schema: z.number().int().gte(0).optional(),
+      },
+      {
+        name: 'status',
+        type: 'Query',
+        schema: z
+          .enum(['completed', 'failed', 'in_progress', 'cancelled'])
+          .optional(),
+      },
+      {
+        name: 'created_before',
+        type: 'Query',
+        schema: z.string().optional(),
+      },
+      {
+        name: 'created_after',
+        type: 'Query',
+        schema: z.string().optional(),
+      },
+    ],
+    response: QueryListResponse,
+    errors: [
+      {
+        status: 500,
+        description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'get',
+    path: '/query/schema',
+    alias: 'getQuerySchema',
+    description: `Introspect the virtual tables and per-collection extracted fields available to SQL queries over the given collections. Use this to discover column names, entity field names, types, and levels, plus each collection&#x27;s verbatim extract schema and prompt, before writing a query.
+
+Fields with level &#x27;file&#x27; appear as rows in the entities table; fields with level &#x27;segment&#x27; live inside the segment_entities.entities JSON column.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'collections',
+        type: 'Query',
+        schema: z.string(),
+      },
+    ],
+    response: QuerySchema,
+    errors: [
+      {
+        status: 400,
+        description: `Invalid request parameters`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 404,
+        description: `One or more collections not found`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 500,
+        description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'get',
+    path: '/query/:id',
+    alias: 'getQuery',
+    description: `Retrieve a stored query run by its ID, including its result rows. Results larger than the inline storage cap are replayed truncated (truncated: true).`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: QueryResult,
+    errors: [
+      {
+        status: 404,
+        description: `Query result not found`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 500,
+        description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'post',
+    path: '/query/:id/cancel',
+    alias: 'cancelQueryExport',
+    description: `Cancel an in-progress background export. The run is marked cancelled synchronously, the export stream is aborted mid-flight (the partial upload is discarded), and the reserved credits are refunded. A run that has already completed or failed is returned unchanged.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: QueryResult,
+    errors: [
+      {
+        status: 404,
+        description: `Query result not found`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+]);
+
+export const QueryApi = new Zodios('https://api.cloudglue.dev/v1', endpoints);
+
+export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
+  return new Zodios(baseUrl, endpoints, options);
+}

--- a/generated/Response.ts
+++ b/generated/Response.ts
@@ -11,7 +11,9 @@ type Response = Partial<{
   created_at: number;
   model: string;
   instructions: string | null;
-  output: Array<ResponseOutputMessage> | null;
+  output: Array<
+    ResponseOutputMessage | ResponseFunctionCall | ResponseQueryCall
+  > | null;
   usage: ResponseUsage;
   error: ResponseError | null;
 }>;
@@ -51,6 +53,23 @@ type ResponseAnnotation = {
   speech?: Array<string> | undefined;
   audio_description?: Array<string> | undefined;
 };
+type ResponseFunctionCall = Partial<{
+  type: 'function_call';
+  id: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+}>;
+type ResponseQueryCall = Partial<{
+  type: 'cloudglue_query_call';
+  id: string;
+  status: 'completed' | 'failed';
+  sql: string;
+  row_count: number;
+  total_rows: number | null;
+  truncated: boolean;
+  error: string | null;
+}>;
 type ResponseUsage = Partial<{
   input_tokens: number;
   output_tokens: number;
@@ -235,6 +254,31 @@ const ResponseOutputMessage: z.ZodType<ResponseOutputMessage> = z
   .partial()
   .strict()
   .passthrough();
+const ResponseFunctionCall: z.ZodType<ResponseFunctionCall> = z
+  .object({
+    type: z.literal('function_call'),
+    id: z.string(),
+    call_id: z.string(),
+    name: z.string(),
+    arguments: z.string(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const ResponseQueryCall: z.ZodType<ResponseQueryCall> = z
+  .object({
+    type: z.literal('cloudglue_query_call'),
+    id: z.string(),
+    status: z.enum(['completed', 'failed']),
+    sql: z.string(),
+    row_count: z.number().int(),
+    total_rows: z.number().int().nullable(),
+    truncated: z.boolean(),
+    error: z.string().nullable(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
 const ResponseUsage: z.ZodType<ResponseUsage> = z
   .object({
     input_tokens: z.number().int(),
@@ -257,7 +301,15 @@ const Response: z.ZodType<Response> = z
     created_at: z.number().int(),
     model: z.string(),
     instructions: z.string().nullable(),
-    output: z.array(ResponseOutputMessage).nullable(),
+    output: z
+      .array(
+        z.union([
+          ResponseOutputMessage,
+          ResponseFunctionCall,
+          ResponseQueryCall,
+        ])
+      )
+      .nullable(),
     usage: ResponseUsage,
     error: ResponseError.nullable(),
   })
@@ -312,6 +364,8 @@ export const schemas = {
   ResponseAnnotation,
   ResponseOutputContent,
   ResponseOutputMessage,
+  ResponseFunctionCall,
+  ResponseQueryCall,
   ResponseUsage,
   ResponseError,
   Response,

--- a/generated/index.ts
+++ b/generated/index.ts
@@ -16,3 +16,4 @@ export { SegmentsApi } from './Segments';
 export { Face_MatchApi } from './Face_Match';
 export { Face_DetectionApi } from './Face_Detection';
 export { ShareApi } from './Share';
+export { QueryApi } from './Query';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.22",
+      "version": "0.7.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/query.api.ts
+++ b/src/api/query.api.ts
@@ -1,0 +1,113 @@
+import { QueryApi } from '../../generated';
+import { schemas } from '../../generated/Query';
+import { CloudglueError } from '../error';
+import { WaitForReadyOptions } from '../types';
+import z from 'zod';
+
+export class EnhancedQueryApi {
+  constructor(private readonly api: typeof QueryApi) {}
+
+  /**
+   * Run a read-only SQL query over the structured data extracted from one or
+   * more collections. Queries execute against three virtual tables — `files`,
+   * `entities`, and `segment_entities` — built from each file's most recent
+   * completed extraction.
+   *
+   * Provide exactly one of `sql` (2 credits) or `query`, a natural-language
+   * question that Cloudglue compiles to SQL against the same virtual schema
+   * (4 credits; the compiled statement is returned in the result's `sql`
+   * field). Use `dry_run` to validate/compile without executing, and
+   * `background` with `format` for large exports retrievable via
+   * `download_url`. Results are stored, so completed runs can be re-fetched
+   * with `getQuery()`.
+   *
+   * @param params - Query execution parameters
+   * @returns The query result (inline rows, or export state when background)
+   */
+  async runQuery(params: z.infer<typeof schemas.RunQueryRequest>) {
+    return this.api.runQuery(params);
+  }
+
+  /**
+   * Introspect the virtual tables and per-collection extracted fields
+   * available to SQL queries over the given collections — column names,
+   * entity field names, types, and levels, plus each collection's verbatim
+   * extract schema and prompt. Use before writing a query.
+   *
+   * @param collectionIds - Collection IDs to introspect (1-20)
+   * @returns The queryable schema for those collections
+   */
+  async getQuerySchema(collectionIds: string[]) {
+    return this.api.getQuerySchema({
+      queries: { collections: collectionIds.join(',') },
+    });
+  }
+
+  /**
+   * List query runs with pagination and filtering. List items omit the
+   * `columns` and `rows` payloads — fetch an individual run via `getQuery()`
+   * for the full result.
+   */
+  async listQueries(
+    params: {
+      limit?: number;
+      offset?: number;
+      status?: 'completed' | 'failed' | 'in_progress' | 'cancelled';
+      created_before?: string;
+      created_after?: string;
+    } = {},
+  ) {
+    return this.api.listQueries({ queries: params });
+  }
+
+  /**
+   * Retrieve a stored query run by ID, including its result rows. Results
+   * larger than the inline storage cap are replayed truncated
+   * (`truncated: true`).
+   */
+  async getQuery(queryId: string) {
+    return this.api.getQuery({ params: { id: queryId } });
+  }
+
+  /**
+   * Cancel an in-progress background export. The run is marked cancelled
+   * synchronously, the export stream is aborted mid-flight (the partial
+   * upload is discarded), and reserved credits are refunded. A run that has
+   * already completed or failed is returned unchanged.
+   */
+  async cancelQueryExport(queryId: string) {
+    return this.api.cancelQueryExport(undefined, { params: { id: queryId } });
+  }
+
+  /**
+   * Waits for a background query export to reach a terminal state
+   * (completed, failed, or cancelled) by polling `getQuery()`.
+   *
+   * @param queryId - The ID of the query run to wait for
+   * @param options - Optional polling configuration
+   * @returns The final query result
+   * @throws {CloudglueError} If the run fails or maxAttempts is reached
+   */
+  async waitForReady(queryId: string, options: WaitForReadyOptions = {}) {
+    const { pollingInterval = 5000, maxAttempts = 36 } = options;
+    let attempts = 0;
+
+    while (attempts < maxAttempts) {
+      const run = await this.getQuery(queryId);
+
+      if (['completed', 'failed', 'cancelled'].includes(run.status ?? '')) {
+        if (run.status === 'failed') {
+          throw new CloudglueError(`Query run failed: ${queryId}`);
+        }
+        return run;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, pollingInterval));
+      attempts++;
+    }
+
+    throw new CloudglueError(
+      `Timeout waiting for query run ${queryId} to process after ${maxAttempts} attempts`,
+    );
+  }
+}

--- a/src/api/query.api.ts
+++ b/src/api/query.api.ts
@@ -97,7 +97,10 @@ export class EnhancedQueryApi {
 
       if (['completed', 'failed', 'cancelled'].includes(run.status ?? '')) {
         if (run.status === 'failed') {
-          throw new CloudglueError(`Query run failed: ${queryId}`);
+          const detail = run.error?.message
+            ? ` — ${run.error.code ?? 'error'}: ${run.error.message}`
+            : '';
+          throw new CloudglueError(`Query run failed: ${queryId}${detail}`);
         }
         return run;
       }

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,6 +10,7 @@ import { createApiClient as createSegmentationsApiClient } from '../generated/Se
 import { createApiClient as createSearchApiClient } from '../generated/Search';
 import { createApiClient as createDescribeApiClient } from '../generated/Describe';
 import { createApiClient as createSegmentsApiClient } from '../generated/Segments';
+import { createApiClient as createQueryApiClient } from '../generated/Query';
 import { createApiClient as createWebhooksApiClient } from '../generated/Webhooks';
 import { createApiClient as createFramesApiClient } from '../generated/Frames';
 import { createApiClient as createFaceDetectionApiClient } from '../generated/Face_Detection';
@@ -32,6 +33,7 @@ import { EnhancedFramesApi } from './api/frame-extraction.api';
 import { EnhancedSearchApi } from './api/search.api';
 import { EnhancedSegmentationsApi } from './api/segmentations.api';
 import { EnhancedSegmentsApi } from './api/segments.api';
+import { EnhancedQueryApi } from './api/query.api';
 import { EnhancedTranscribeApi } from './api/transcribe.api';
 import { EnhancedChatApi } from './api/chat-completion.api';
 import { EnhancedCollectionsApi } from './api/collections.api';
@@ -77,6 +79,12 @@ export class Cloudglue {
    * Provides methods for extracting specific information from video content
    */
   public readonly extract: EnhancedExtractApi;
+
+  /**
+   * Query API for running read-only SQL (or natural-language) queries over
+   * the structured data extracted from collections
+   */
+  public readonly query: EnhancedQueryApi;
 
   /**
    * Segmentations API for segmenting videos into shots
@@ -188,6 +196,7 @@ export class Cloudglue {
     const chatApi = createChatApiClient(this.baseUrl, sharedConfig);
     const transcribeApi = createTranscribeApiClient(this.baseUrl, sharedConfig);
     const extractApi = createExtractApiClient(this.baseUrl, sharedConfig);
+    const queryApi = createQueryApiClient(this.baseUrl, sharedConfig);
     const segmentationsApi = createSegmentationsApiClient(
       this.baseUrl,
       sharedConfig,
@@ -221,6 +230,7 @@ export class Cloudglue {
       chatApi,
       transcribeApi,
       extractApi,
+      queryApi,
       segmentationsApi,
       searchApi,
       describeApi,
@@ -288,6 +298,7 @@ export class Cloudglue {
     this.chat = new EnhancedChatApi(chatApi);
     this.transcribe = new EnhancedTranscribeApi(transcribeApi);
     this.extract = new EnhancedExtractApi(extractApi);
+    this.query = new EnhancedQueryApi(queryApi);
     this.segmentations = new EnhancedSegmentationsApi(segmentationsApi);
     this.search = new EnhancedSearchApi(searchApi);
     this.describe = new EnhancedDescribeApi(describeApi);

--- a/src/types.ts
+++ b/src/types.ts
@@ -500,6 +500,22 @@ export type ResponseOutputMessage = z.infer<
 >;
 
 /**
+ * Represents a Response API function-call output item (type 'function_call')
+ */
+export type ResponseFunctionCall = z.infer<
+  typeof responseSchemas.ResponseFunctionCall
+>;
+
+/**
+ * Represents a Response API query-call output item
+ * (type 'cloudglue_query_call') — a SQL query the model ran against the
+ * knowledge base's entity collections, with row counts and truncation state
+ */
+export type ResponseQueryCall = z.infer<
+  typeof responseSchemas.ResponseQueryCall
+>;
+
+/**
  * Represents a citation annotation in a Response API response
  */
 export type ResponseAnnotation = z.infer<

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ import { schemas as tagsSchemas } from '../generated/Tags';
 import { schemas as shareableSchemas } from '../generated/Share';
 import { schemas as dataConnectorsSchemas } from '../generated/Data_Connectors';
 import { schemas as deepSearchSchemas } from '../generated/Deep_Search';
+import { schemas as querySchemas } from '../generated/Query';
 
 /**
  * Represents a video file in the Cloudglue system
@@ -621,3 +622,33 @@ export type {
 
 // Re-export Data Connector file browsing params
 export type { ListDataConnectorFilesParams } from './api/data-connectors.api';
+
+/**
+ * Parameters for running a SQL or natural-language query over collections
+ */
+export type RunQueryRequest = z.infer<typeof querySchemas.RunQueryRequest>;
+
+/**
+ * Represents a query run, including inline result rows or export state
+ */
+export type QueryResult = z.infer<typeof querySchemas.QueryResult>;
+
+/**
+ * Represents a query run list item (columns/rows omitted)
+ */
+export type QueryListItem = z.infer<typeof querySchemas.QueryListItem>;
+
+/**
+ * Represents a paginated list of query runs
+ */
+export type QueryListResponse = z.infer<typeof querySchemas.QueryListResponse>;
+
+/**
+ * Represents the queryable virtual schema for a set of collections
+ */
+export type QuerySchema = z.infer<typeof querySchemas.QuerySchema>;
+
+/**
+ * Represents credit usage for a query run
+ */
+export type QueryUsage = z.infer<typeof querySchemas.QueryUsage>;


### PR DESCRIPTION
## Summary

Syncs the SDK to spec **v0.7.15** (cloudglue/cloudglue-api-spec#107) and bumps the package to **0.7.23**.

The headline is the new **Query API** — read-only SQL (or natural language) over the structured data extracted from collections, against the `files`/`entities`/`segment_entities` virtual tables — plus query-call output items on the Response API and an ephemeral `thumbnail_url` on data-connector file listings.

### Generated
- New `Query` client: `runQuery`, `listQueries`, `getQuerySchema`, `getQuery`, `cancelQueryExport` + all Query schemas
- `Response.output` items: `oneOf` message | function_call | query_call
- `DataConnectorFile.thumbnail_url` (nullable, ephemeral signed provider preview)

### Wrapper (src/)
- New `cg.query` resource (`EnhancedQueryApi`): `runQuery` (sql or natural-language, typed via `z.infer<RunQueryRequest>`), `getQuerySchema(collectionIds)` (joins IDs into the comma-separated param), `listQueries`, `getQuery`, `cancelQueryExport`, and `waitForReady` for background exports
- Wired through `client.ts`; `RunQueryRequest`/`QueryResult`/`QueryListItem`/`QueryListResponse`/`QuerySchema`/`QueryUsage` re-exported from `types.ts`

## Test plan

- [x] `npm run build` clean, `npm test` 107/107
- [x] Live battery against **staging** — **12/12** (evidence in `~/Downloads/cloudglue-v0.7.15-sdk-test-results.md`): schema introspection lists the three virtual tables + per-collection fields; SQL `SELECT COUNT(*)` returns inline rows with scan-stat usage; natural-language query returns the compiled SQL; `dry_run` validates without rows; non-SELECT and face-analysis-collection requests 400; list omits rows while get replays them; background CSV export cancels cleanly; gong/recall listings parse with the optional `thumbnail_url`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a large new client surface and widens Response output typing; consumers parsing `output` must handle new item types, but changes are spec-driven and mostly additive.
> 
> **Overview**
> Syncs the SDK to API spec **v0.7.15** and bumps the package to **0.7.23**.
> 
> **Query API** is the main addition: generated `Query` client plus `EnhancedQueryApi` exposed as `client.query`, with `runQuery` (SQL or natural language), schema introspection, list/get, export cancel, and `waitForReady` for background exports. Related Query types are re-exported from `types.ts`.
> 
> **Response API** `output` items are now a union of assistant messages, `function_call`, and `cloudglue_query_call` (SQL the model ran against entity collections), with matching exported types.
> 
> **Data connectors** gain optional `thumbnail_url` on listed files. The **Files** `syncFileSourceMetadata` docs note Iconik poster keyframe behavior when a thumbnail is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e087556b18cfb15a65bae6c14155a290c28a433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->