### PR TITLE
feat: entity and metadata collections in search, deep search, and response KBs (spec v0.7.16)

### DIFF
--- a/generated/Collections.ts
+++ b/generated/Collections.ts
@@ -169,6 +169,9 @@ type CollectionFile = {
   object: 'collection_file';
   added_at: number;
   status: 'pending' | 'processing' | 'completed' | 'failed' | 'not_applicable';
+  searchable_status?:
+    | ('pending' | 'processing' | 'completed' | 'failed')
+    | undefined;
   file?: File | undefined;
   segmentation?:
     | {
@@ -522,6 +525,9 @@ const CollectionFile: z.ZodType<CollectionFile> = z
       'failed',
       'not_applicable',
     ]),
+    searchable_status: z
+      .enum(['pending', 'processing', 'completed', 'failed'])
+      .optional(),
     file: File.optional(),
     segmentation: z
       .object({

--- a/generated/Deep_Search.ts
+++ b/generated/Deep_Search.ts
@@ -10,7 +10,7 @@ type DeepSearch = Partial<{
   status: 'in_progress' | 'completed' | 'failed' | 'cancelled';
   created_at: number;
   query: string;
-  scope: 'segment' | 'file';
+  scope: 'segment' | 'file' | null;
   text: string | null;
   results: Array<DeepSearchResult> | null;
   total: number;
@@ -91,7 +91,7 @@ type DeepSearchListItem = Partial<{
   status: 'in_progress' | 'completed' | 'failed' | 'cancelled';
   created_at: number;
   query: string;
-  scope: 'segment' | 'file';
+  scope: 'segment' | 'file' | null;
   total: number;
   usage: DeepSearchUsage;
 }>;
@@ -178,7 +178,7 @@ const DeepSearch: z.ZodType<DeepSearch> = z
     status: z.enum(['in_progress', 'completed', 'failed', 'cancelled']),
     created_at: z.number(),
     query: z.string(),
-    scope: z.enum(['segment', 'file']),
+    scope: z.enum(['segment', 'file']).nullable(),
     text: z.string().nullable(),
     results: z.array(DeepSearchResult).nullable(),
     total: z.number().int(),
@@ -202,7 +202,7 @@ const DeepSearchListItem: z.ZodType<DeepSearchListItem> = z
     status: z.enum(['in_progress', 'completed', 'failed', 'cancelled']),
     created_at: z.number(),
     query: z.string(),
-    scope: z.enum(['segment', 'file']),
+    scope: z.enum(['segment', 'file']).nullable(),
     total: z.number().int(),
     usage: DeepSearchUsage,
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.23",
+      "version": "0.7.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",
@@ -959,9 +959,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1234,9 +1234,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/deep-search.api.ts
+++ b/src/api/deep-search.api.ts
@@ -6,6 +6,10 @@ import { CloudglueError } from '../error';
 type DeepSearchStatus = 'in_progress' | 'completed' | 'failed' | 'cancelled';
 
 export type DeepSearchKnowledgeBase =
+  /**
+   * Collections may be of type rich-transcripts, media-descriptions,
+   * metadata, or entities.
+   */
   | { source: 'collections'; collections: string[]; filter?: SearchFilter }
   | { source: 'files'; files: string[] }
   | { source: 'default' };
@@ -15,7 +19,16 @@ export interface CreateDeepSearchParams {
   knowledge_base: DeepSearchKnowledgeBase;
   /** The search query */
   query: string;
-  /** Search scope - segment-level or file-level */
+  /**
+   * Search scope. `'segment'` returns individual segments, `'file'` returns
+   * file-level results — with an explicit value, every collection in the
+   * knowledge base must be searchable at that scope (metadata and file-level
+   * entities collections require `'file'`; segment-level entities
+   * collections require `'segment'`). Omit for auto: the search planner
+   * picks a scope per search plan, each collection is searched at the scope
+   * it supports, and results may mix segment and file types (the response's
+   * `scope` is null).
+   */
   scope?: 'segment' | 'file';
   /** Maximum number of results to return (1-500) */
   limit?: number;


### PR DESCRIPTION
## Summary

Syncs the SDK to spec **v0.7.16** (cloudglue/cloudglue-api-spec#108) and bumps the package to **0.7.24**.

Entities and metadata collections become first-class search sources: direct search, deep-search KBs, and Response API KBs all accept them, deep search gains an **auto scope** mode (response `scope` is now nullable — null = the planner chose scopes per search plan), and `CollectionFile` gains `searchable_status`.

### Generated
- `CollectionFile.searchable_status` (`pending`/`processing`/`completed`/`failed`)
- `DeepSearch.scope` / `DeepSearchListItem.scope` nullable (null = auto)
- Broadened collection-type acceptance + `doc_lexical` over entity docs (doc-level)

### Wrapper (src/)
- **Docs only** — `CreateDeepSearchParams.scope` was already optional so auto mode works as-is; documented auto vs explicit scope semantics (metadata + file-level entities → `file`, segment-level entities → `segment`) and the accepted KB collection types. Response-side nullable scope and `searchable_status` flow via `z.infer`.

## Test plan

- [x] `npm run build` clean, `npm test` 107/107
- [x] Live battery against **production** — **7/7** (evidence in `~/Downloads/cloudglue-v0.7.16-sdk-test-results.md`): `searchable_status` enum values on entities + media-descriptions listings; segment search over an entities collection returns results; file-scope over a segment-level entities collection 400s with a clear message; **auto deep search over a mixed KB completes with `scope=null` and results mixing segment+file types**; explicit scope still completes and is echoed; `nimbus-002-preview` accepts an entities-collection KB while `nimbus-001` 400s. Created response deleted at cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive generated types and documentation with an optional version bump; consumers should treat nullable `scope` on responses but request APIs are unchanged.
> 
> **Overview**
> Bumps **@cloudglue/cloudglue-js** to **0.7.24** and refreshes generated types from API spec **v0.7.16** for entities/metadata collections in search flows.
> 
> **`CollectionFile`** now exposes optional **`searchable_status`** (`pending` / `processing` / `completed` / `failed`) so callers can see indexing readiness separately from overall file processing **`status`**.
> 
> **Deep search** responses treat **`scope`** as **`'segment' | 'file' | null`**: **`null`** means auto mode (planner chose scope per plan; results may mix segment and file hits). Request **`scope`** stays optional in generated **`CreateDeepSearchRequest`**.
> 
> The **`src/api/deep-search.api.ts`** wrapper only adds JSDoc—documenting auto vs explicit scope rules (metadata and file-level entities → **`file`**, segment-level entities → **`segment`**) and which collection types are valid in collection KBs. No runtime behavior change in the wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55625182a8ed50c4088917a69e2bd37ac8ff65d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->