### PR TITLE
fix: resolve Dependabot security alerts (axios, brace-expansion, fast-uri, js-yaml)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",
-        "axios": "^1.12.0",
+        "axios": "^1.18.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -959,9 +959,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1234,9 +1234,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/cloudglue/cloudglue-js#readme",
   "dependencies": {
     "@zodios/core": "^10.0.0",
-    "axios": "^1.12.0",
+    "axios": "^1.18.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -51,13 +51,14 @@
   },
   "pnpm": {
     "overrides": {
-      "js-yaml": "^4.2.0",
-      "axios": "^1.12.0",
+      "js-yaml": "^4.3.0",
+      "axios": "^1.18.0",
       "glob": "^13.0.3",
       "ajv": "^8.18.0",
+      "fast-uri": "^3.1.5",
       "minimatch": "^10.2.3",
       "handlebars": "^4.7.9",
-      "brace-expansion": "^5.0.5",
+      "brace-expansion": "^5.0.9",
       "yaml": "^2.8.3",
       "form-data": "^4.0.6",
       "@babel/core": "^7.29.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml: ^4.2.0
-  axios: ^1.12.0
+  js-yaml: ^4.3.0
+  axios: ^1.18.0
   glob: ^13.0.3
   ajv: ^8.18.0
+  fast-uri: ^3.1.5
   minimatch: ^10.2.3
   handlebars: ^4.7.9
-  brace-expansion: ^5.0.5
+  brace-expansion: ^5.0.9
   yaml: ^2.8.3
   form-data: ^4.0.6
   '@babel/core': ^7.29.6
@@ -23,10 +24,10 @@ importers:
     dependencies:
       '@zodios/core':
         specifier: ^10.0.0
-        version: 10.9.6(axios@1.17.0)(zod@3.25.76)
+        version: 10.9.6(axios@1.19.0)(zod@3.25.76)
       axios:
-        specifier: ^1.12.0
-        version: 1.17.0
+        specifier: ^1.18.0
+        version: 1.19.0
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -342,7 +343,7 @@ packages:
   '@zodios/core@10.9.6':
     resolution: {integrity: sha512-aH4rOdb3AcezN7ws8vDgBfGboZMk2JGGzEq/DtW65MhnRxyTGRuLJRWVQ/2KxDgWvV2F5oTkAS+5pnjKbl0n+A==}
     peerDependencies:
-      axios: ^1.12.0
+      axios: ^1.18.0
       zod: ^3.x
 
   agent-base@6.0.2:
@@ -366,16 +367,16 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.17.0:
-    resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.25.3:
     resolution: {integrity: sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==}
@@ -454,8 +455,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -529,8 +530,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -724,7 +725,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
 
   '@apidevtools/openapi-schemas@2.1.0': {}
 
@@ -968,9 +969,9 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
-  '@zodios/core@10.9.6(axios@1.17.0)(zod@3.25.76)':
+  '@zodios/core@10.9.6(axios@1.19.0)(zod@3.25.76)':
     dependencies:
-      axios: 1.17.0
+      axios: 1.19.0
       zod: 3.25.76
 
   agent-base@6.0.2:
@@ -986,7 +987,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -994,7 +995,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.17.0:
+  axios@1.19.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
@@ -1006,7 +1007,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -1098,7 +1099,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.5: {}
 
   follow-redirects@1.16.0: {}
 
@@ -1179,7 +1180,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -1211,7 +1212,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -1229,8 +1230,8 @@ snapshots:
     dependencies:
       '@apidevtools/swagger-parser': 10.1.1(openapi-types@12.1.3)
       '@liuli-util/fs-extra': 0.1.0
-      '@zodios/core': 10.9.6(axios@1.17.0)(zod@3.25.76)
-      axios: 1.17.0
+      '@zodios/core': 10.9.6(axios@1.19.0)(zod@3.25.76)
+      axios: 1.19.0
       cac: 6.7.14
       handlebars: 4.7.9
       openapi-types: 12.1.3


### PR DESCRIPTION
## Summary

- Resolves all open Dependabot alerts (6 high, 9 moderate on the default branch) by bumping the vulnerable packages in both lockfiles:
  - **axios** `^1.12.0` → `^1.18.0` (runtime dependency; lockfiles resolve to 1.19.0) — clears 12 advisories including the high-severity inherited-proxy issue ([GHSA-gcfj-64vw-6mp9](https://github.com/advisories/GHSA-gcfj-64vw-6mp9)), prototype pollution, formToJSON DoS, NO_PROXY bypass, and `maxBodyLength` bypass issues
  - **brace-expansion** override `^5.0.5` → `^5.0.9` — three high-severity DoS advisories ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp), [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895))
  - **fast-uri** override added at `^3.1.5` — host-confusion advisories ([GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7), [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx), [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6))
  - **js-yaml** override `^4.2.0` → `^4.3.0` — quadratic CPU via merge-key chains ([GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m))
- Refreshed `pnpm-lock.yaml` and `package-lock.json`; `pnpm audit` and `npm audit` both report 0 vulnerabilities after the change.

## Test plan

- [x] `pnpm audit` reports 0 vulnerabilities
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run build` succeeds
- [x] `npm test` — all 107 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkBEq4UqzxoLbkQYT5zymY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkBEq4UqzxoLbkQYT5zymY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only security bumps with no application code changes; main residual risk is subtle axios behavior differences in HTTP/upload paths.
> 
> **Overview**
> Addresses open Dependabot advisories by raising dependency versions and **pnpm** overrides, then refreshing **`package-lock.json`** and **`pnpm-lock.yaml`**.
> 
> **axios** moves from `^1.12.0` to `^1.18.0` in direct dependencies and overrides (lockfiles resolve to 1.19.x), covering the runtime HTTP client used by Zodios and multipart uploads. Transitive pins are updated via overrides: **js-yaml** `^4.2.0` → `^4.3.0`, **brace-expansion** `^5.0.5` → `^5.0.9`, and a new **fast-uri** override at `^3.1.5`. No SDK source or API surface changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54551eb4801c1731cd3807c1aa26e7ebfad90ca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->