### PR TITLE
feat: player link previews, share clip params, deep search auto scope (spec v0.7.16)

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -158,5 +158,10 @@ const describes = await client.segmentations.listSegmentationDescribes(segmentat
 // visibility defaults to 'public' (viewable by anyone with the link);
 // pass visibility: 'private' for account-restricted, token-gated playback.
 // A file (or segment) can have at most one active share per visibility.
+// link_preview ('none' | 'full' | 'player') controls Open Graph metadata
+// for unfurl bots on private shares; 'player' lets the share play inline
+// when unfurled by the Cloudglue Slack app.
+// getShareableAsset(id, { clip_start, clip_end }) returns a stream_url
+// that plays only that window (seconds, both required together).
 // See source: src/api/shareable.api.ts
 ```

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -68,6 +68,11 @@ const videos = await client.collections.listVideos(collectionId, {
 // Get/delete a specific video
 const video = await client.collections.getVideo(collectionId, fileId);
 await client.collections.deleteVideo(collectionId, fileId);
+
+// Videos in searchable collections (media-descriptions, rich-transcripts,
+// metadata, entities) also report searchable_status ('pending' |
+// 'processing' | 'completed' | 'failed') — indexing progress of the
+// file's search documents.
 ```
 
 ## Retrieve Processed Data

--- a/docs/deep-search.md
+++ b/docs/deep-search.md
@@ -11,7 +11,9 @@ const result = await client.deepSearch.createDeepSearch({
     collections: ['col_id'],
   },
   query: 'What pricing strategies were discussed?',
-  scope: 'segment',          // 'segment' or 'file'
+  scope: 'segment',          // 'segment' or 'file'; omit for auto (the
+                             // planner picks scopes per search plan and
+                             // fuses results; responses report scope: null)
   limit: 50,                 // max results (1-500)
   exclude_weak_results: true,
   include: ['search_queries'], // include the intermediate search queries used

--- a/generated/Collections.ts
+++ b/generated/Collections.ts
@@ -169,6 +169,9 @@ type CollectionFile = {
   object: 'collection_file';
   added_at: number;
   status: 'pending' | 'processing' | 'completed' | 'failed' | 'not_applicable';
+  searchable_status?:
+    | ('pending' | 'processing' | 'completed' | 'failed')
+    | undefined;
   file?: File | undefined;
   segmentation?:
     | {
@@ -522,6 +525,9 @@ const CollectionFile: z.ZodType<CollectionFile> = z
       'failed',
       'not_applicable',
     ]),
+    searchable_status: z
+      .enum(['pending', 'processing', 'completed', 'failed'])
+      .optional(),
     file: File.optional(),
     segmentation: z
       .object({

--- a/generated/Deep_Search.ts
+++ b/generated/Deep_Search.ts
@@ -10,7 +10,7 @@ type DeepSearch = Partial<{
   status: 'in_progress' | 'completed' | 'failed' | 'cancelled';
   created_at: number;
   query: string;
-  scope: 'segment' | 'file';
+  scope: 'segment' | 'file' | null;
   text: string | null;
   results: Array<DeepSearchResult> | null;
   total: number;
@@ -91,7 +91,7 @@ type DeepSearchListItem = Partial<{
   status: 'in_progress' | 'completed' | 'failed' | 'cancelled';
   created_at: number;
   query: string;
-  scope: 'segment' | 'file';
+  scope: 'segment' | 'file' | null;
   total: number;
   usage: DeepSearchUsage;
 }>;
@@ -178,7 +178,7 @@ const DeepSearch: z.ZodType<DeepSearch> = z
     status: z.enum(['in_progress', 'completed', 'failed', 'cancelled']),
     created_at: z.number(),
     query: z.string(),
-    scope: z.enum(['segment', 'file']),
+    scope: z.enum(['segment', 'file']).nullable(),
     text: z.string().nullable(),
     results: z.array(DeepSearchResult).nullable(),
     total: z.number().int(),
@@ -202,7 +202,7 @@ const DeepSearchListItem: z.ZodType<DeepSearchListItem> = z
     status: z.enum(['in_progress', 'completed', 'failed', 'cancelled']),
     created_at: z.number(),
     query: z.string(),
-    scope: z.enum(['segment', 'file']),
+    scope: z.enum(['segment', 'file']).nullable(),
     total: z.number().int(),
     usage: DeepSearchUsage,
   })

--- a/generated/Share.ts
+++ b/generated/Share.ts
@@ -9,7 +9,7 @@ type ShareableAsset = {
   description?: string | undefined;
   metadata?: {} | undefined;
   visibility?: ('public' | 'private') | undefined;
-  link_preview: 'none' | 'full';
+  link_preview: 'none' | 'full' | 'player';
   preview_url?: string | undefined;
   media_download_url?: string | undefined;
   media_download_expires_at?: (number | null) | undefined;
@@ -37,7 +37,7 @@ const ShareableAsset: z.ZodType<ShareableAsset> = z
     description: z.string().optional(),
     metadata: z.object({}).partial().strict().passthrough().optional(),
     visibility: z.enum(['public', 'private']).optional(),
-    link_preview: z.enum(['none', 'full']),
+    link_preview: z.enum(['none', 'full', 'player']),
     preview_url: z.string().optional(),
     media_download_url: z.string().optional(),
     media_download_expires_at: z.number().nullish(),
@@ -68,7 +68,7 @@ const CreateShareableAssetRequest = z
     description: z.string().optional(),
     metadata: z.object({}).partial().strict().passthrough().optional(),
     visibility: z.enum(['public', 'private']).optional(),
-    link_preview: z.enum(['none', 'full']).optional(),
+    link_preview: z.enum(['none', 'full', 'player']).optional(),
   })
   .strict()
   .passthrough();
@@ -77,7 +77,7 @@ const UpdateShareableAssetRequest = z
     title: z.string(),
     description: z.string(),
     metadata: z.object({}).partial().strict().passthrough(),
-    link_preview: z.enum(['none', 'full']),
+    link_preview: z.enum(['none', 'full', 'player']),
   })
   .partial()
   .strict()
@@ -178,13 +178,23 @@ const endpoints = makeApi([
     method: 'get',
     path: '/share/:id',
     alias: 'getShareableAsset',
-    description: `Get a shareable asset`,
+    description: `Get a shareable asset. Optionally pass an instant-clip window (clip_start/clip_end) to receive a stream_url that plays only that window.`,
     requestFormat: 'json',
     parameters: [
       {
         name: 'id',
         type: 'Path',
         schema: z.string().uuid(),
+      },
+      {
+        name: 'clip_start',
+        type: 'Query',
+        schema: z.number().gte(0).optional(),
+      },
+      {
+        name: 'clip_end',
+        type: 'Query',
+        schema: z.number().gt(0).optional(),
       },
     ],
     response: ShareableAsset,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.23",
+      "version": "0.7.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/deep-search.api.ts
+++ b/src/api/deep-search.api.ts
@@ -15,7 +15,13 @@ export interface CreateDeepSearchParams {
   knowledge_base: DeepSearchKnowledgeBase;
   /** The search query */
   query: string;
-  /** Search scope - segment-level or file-level */
+  /**
+   * Search scope - segment-level or file-level. Omit for auto: the search
+   * planner picks a scope per search plan, each collection is searched at
+   * the scopes its documents support, and results from both scopes are
+   * fused (responses report `scope: null`). With an explicit scope, every
+   * collection in the knowledge base must be searchable at it.
+   */
   scope?: 'segment' | 'file';
   /** Maximum number of results to return (1-500) */
   limit?: number;

--- a/src/api/deep-search.api.ts
+++ b/src/api/deep-search.api.ts
@@ -6,6 +6,10 @@ import { CloudglueError } from '../error';
 type DeepSearchStatus = 'in_progress' | 'completed' | 'failed' | 'cancelled';
 
 export type DeepSearchKnowledgeBase =
+  /**
+   * Collections may be of type rich-transcripts, media-descriptions,
+   * metadata, or entities.
+   */
   | { source: 'collections'; collections: string[]; filter?: SearchFilter }
   | { source: 'files'; files: string[] }
   | { source: 'default' };
@@ -16,11 +20,14 @@ export interface CreateDeepSearchParams {
   /** The search query */
   query: string;
   /**
-   * Search scope - segment-level or file-level. Omit for auto: the search
-   * planner picks a scope per search plan, each collection is searched at
-   * the scopes its documents support, and results from both scopes are
-   * fused (responses report `scope: null`). With an explicit scope, every
-   * collection in the knowledge base must be searchable at it.
+   * Search scope. `'segment'` returns individual segments, `'file'` returns
+   * file-level results — with an explicit value, every collection in the
+   * knowledge base must be searchable at that scope (metadata and file-level
+   * entities collections require `'file'`; segment-level entities
+   * collections require `'segment'`). Omit for auto: the search planner
+   * picks a scope per search plan, each collection is searched at the scope
+   * it supports, and results may mix segment and file types (the response's
+   * `scope` is null).
    */
   scope?: 'segment' | 'file';
   /** Maximum number of results to return (1-500) */

--- a/src/api/shareable.api.ts
+++ b/src/api/shareable.api.ts
@@ -12,7 +12,17 @@ export class EnhancedShareableApi {
     fileSegmentId?: string;
     visibility?: 'public' | 'private';
   }) {
-    return this.api.listShareableAssets({ queries: data });
+    return this.api.listShareableAssets({
+      queries: {
+        limit: data.limit,
+        offset: data.offset,
+        created_before: data.createdBefore,
+        created_after: data.createdAfter,
+        file_id: data.fileId,
+        file_segment_id: data.fileSegmentId,
+        visibility: data.visibility,
+      },
+    });
   }
 
   /**
@@ -21,7 +31,11 @@ export class EnhancedShareableApi {
    * `link_preview` controls rich Open Graph metadata for unfurl bots (Slack,
    * iMessage, etc.) and only affects **private** shares: `'none'` (the API
    * default) emits no preview metadata, `'full'` emits title, description,
-   * and thumbnail tags. Public shares always emit full metadata regardless.
+   * and thumbnail tags, and `'player'` additionally lets the share play
+   * inline when its link is unfurled by the Cloudglue Slack app — anyone who
+   * can see the Slack message can play it. Public shares always emit full
+   * metadata (and unfurl playable where the Slack app is installed)
+   * regardless.
    */
   async createShareableAsset(data: {
     file_id: string;
@@ -30,14 +44,27 @@ export class EnhancedShareableApi {
     description?: string;
     metadata?: Record<string, unknown>;
     visibility?: 'public' | 'private';
-    link_preview?: 'none' | 'full';
+    link_preview?: 'none' | 'full' | 'player';
   }) {
     return this.api.createShareableAsset(data);
   }
 
-  async getShareableAsset(id: string) {
+  /**
+   * Get a shareable asset.
+   *
+   * Optionally pass an instant-clip window: `clip_start`/`clip_end` are
+   * seconds, must be provided together, with `clip_end > clip_start`. When
+   * set, the returned `stream_url` plays only that window — the share itself
+   * is untouched, and reads without the params keep returning the
+   * full-asset stream.
+   */
+  async getShareableAsset(
+    id: string,
+    queries?: { clip_start?: number; clip_end?: number },
+  ) {
     return this.api.getShareableAsset({
       params: { id },
+      queries,
     });
   }
 
@@ -45,8 +72,10 @@ export class EnhancedShareableApi {
    * Update a shareable asset's presentation fields.
    *
    * `link_preview` toggles rich Open Graph metadata for unfurl bots on
-   * **private** shares (`'none'` or `'full'`); public shares always emit full
-   * metadata. Note `visibility` cannot be changed after creation.
+   * **private** shares: `'none'`, `'full'`, or `'player'` (playable inline
+   * when unfurled by the Cloudglue Slack app; downgrading from `'player'`
+   * revokes playback in already-posted unfurls). Public shares always emit
+   * full metadata. Note `visibility` cannot be changed after creation.
    */
   async updateShareableAsset(
     id: string,
@@ -54,7 +83,7 @@ export class EnhancedShareableApi {
       title?: string;
       description?: string;
       metadata?: Record<string, unknown>;
-      link_preview?: 'none' | 'full';
+      link_preview?: 'none' | 'full' | 'player';
     },
   ) {
     return this.api.updateShareableAsset(data, {
@@ -78,9 +107,7 @@ export class EnhancedShareableApi {
       visibility?: 'public' | 'private';
     },
   ) {
-    return this.api.listShareableAssets({
-      queries: { file_id: fileId, ...queries },
-    });
+    return this.listShareableAssets({ ...queries, fileId });
   }
 
   async getFileSegmentShareableAsset(
@@ -94,8 +121,10 @@ export class EnhancedShareableApi {
       visibility?: 'public' | 'private';
     },
   ) {
-    return this.api.listShareableAssets({
-      queries: { file_id: fileId, file_segment_id: segmentId, ...queries },
+    return this.listShareableAssets({
+      ...queries,
+      fileId,
+      fileSegmentId: segmentId,
     });
   }
 }


### PR DESCRIPTION
## Summary

Syncs the SDK to spec **v0.7.16** (cloudglue/cloudglue-api-spec#109; upstream API change makeyolo/cloudglue#1351) and bumps the package to **0.7.24**.

### Generated (`npm run generate`)

- `link_preview` widened to `'none' | 'full' | 'player'` on `ShareableAsset`, `CreateShareableAssetRequest`, and `UpdateShareableAssetRequest`. Standalone generated clients validate responses by default, so without this regen a share already set to `player` would throw on its own `get`/`list` reads once the backend feature ships (the orchestrating `Cloudglue` client sets `validate: false` and is unaffected).
- `getShareableAsset` gains `clip_start` / `clip_end` query params (documented in the spec as part of #109 — preexisting API behavior from the hard-clip work).
- `CollectionFile` gains `searchable_status` (`pending`/`processing`/`completed`/`failed`).
- `DeepSearch.scope` / `DeepSearchListItem.scope` become nullable (null = request omitted scope, auto).

### Wrapper

- `shareable`: `link_preview` accepts `'player'` in create/update with updated doc comments; `getShareableAsset(id, { clip_start, clip_end })` exposes the instant-clip window (seconds, both-or-neither, `clip_end > clip_start`) — the returned `stream_url` plays only that window.
- **Bugfix**: `listShareableAssets` (and the two file-scoped helpers) passed camelCase query keys (`fileId`, `fileSegmentId`, `createdBefore`, `createdAfter`) straight through — Zodios forwards `queries` verbatim to axios `params`, so the API received unknown keys and silently ignored those filters. They now map to the snake_case wire names, so these filters take effect (behavior change for anyone relying on the filters having been no-ops).
- `deep-search`: `scope` doc comment covers omit-for-auto and `scope: null` in responses.
- Docs: `advanced.md` (share `link_preview` + clip window), `deep-search.md` (auto scope), `collections.md` (`searchable_status`).

### Release timing

makeyolo/cloudglue#1351 is **merged and live in prod** — `link_preview: 'player'` and the clip params are both verified end-to-end below. The SDK should be **released before the feature is announced**, so customers pinned to older SDKs aren't broken by their own `player` reads.

## Test plan

- [x] `npm run build` clean, `npm test` 107/107 pass
- [x] Live battery vs prod (`~/Downloads/cloudglue-js-verify-v0716.ts`), 10/10:
  - offline: regenerated `ShareableAsset` schema accepts `link_preview: 'player'`, still rejects unknown values; `DeepSearch` accepts `scope: null`
  - live: `listShareableAssets` returns (32 shares); `createdBefore: '2020-01-01'` now filters to 0 (snake_case fix — previously ignored)
  - live: `getShareableAsset(id, { clip_start: 1, clip_end: 5 })` returns a different signed `stream_url` whose playback-token claims carry the window (`asset_start_time: "1"`, `asset_end_time: "5"`)
  - live: invalid windows rejected with 400 (`clip_end <= clip_start`, missing half of the pair)
- [x] **Full battery vs prod after makeyolo/cloudglue#1351 went live** — **21/21** (`~/Downloads/cloudglue-js-v0.7.24-battery.ts`, results in `~/Downloads/cloudglue-js-v0.7.24-test-results.md`): `player` end-to-end on a private share (create/get/list echo it; update downgrades to `full` and back; a **standalone generated client with default `validate: true`** reads it without throwing — the exact path that crashed on the old enum); clip window claims + 400s on invalid windows; `createdBefore`/`fileId` filters apply (snake_case fix); `listVideos` exposes `searchable_status`; deep search with omitted scope completes with `scope: null` while explicit `scope: 'segment'` is echoed. All created shares/deep searches deleted at cleanup.

Spec PR cloudglue/cloudglue-api-spec#109 is **merged**; the `spec` submodule points at the merge commit on main (`4799e41`).

Supersedes #149 (earlier sync of the entities/auto-scope half of v0.7.16, from the since-closed spec #108): its generated output is byte-identical to this PR's, and its `DeepSearchKnowledgeBase`/`scope` JSDoc has been ported here. Its 7/7 live entities-search battery stands as evidence for that half.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive schema/docs sync, but the shareable list filter fix changes previously no-op query behavior, and `link_preview: 'player'` affects private-share unfurl playback once the backend feature ships.
> 
> **Overview**
> Syncs the SDK to API spec **v0.7.16** and bumps the package to **0.7.24**, exposing several additive API surface changes plus one shareable list bugfix.
> 
> **Shareable assets:** `link_preview` now accepts `'player'` (inline Slack unfurl playback on private shares). `getShareableAsset` accepts optional `clip_start`/`clip_end` so the returned `stream_url` plays only that window. Also **fixes** `listShareableAssets` (and file-scoped helpers) silently ignoring filters by mapping camelCase params to snake_case wire names.
> 
> **Deep search / collections:** Omitting `scope` enables auto mode (responses report `scope: null`). Collection files gain optional `searchable_status` for search-index progress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a5853a5e7230957c75f24254fc77bd08cd62a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

