### PR TITLE
feat: metadata imports API (spec v0.7.17)

### DIFF
--- a/generated/Metadata_Imports.ts
+++ b/generated/Metadata_Imports.ts
@@ -1,0 +1,478 @@
+import { makeApi, Zodios, type ZodiosOptions } from '@zodios/core';
+import { z } from 'zod';
+
+type MetadataImport = Partial<{
+  object: 'metadata_import';
+  id: string;
+  collection_id: string;
+  connector_id: string;
+  name: string;
+  filters: Array<MetadataImportFilterSet>;
+  default_mode: 'append' | 'refresh';
+  delete_missing: boolean;
+  rate_limit: number | null;
+  created_at: number;
+  latest_run: MetadataImportRun | null;
+  max_files: number | null;
+  include_thumbnails: boolean;
+}>;
+type CreateMetadataImportRequest = {
+  name: string;
+  connector_id: string;
+  filters?: Array<MetadataImportFilterSet> | undefined;
+  default_mode?: ('append' | 'refresh') | undefined;
+  delete_missing?: boolean | undefined;
+  rate_limit?: number | undefined;
+  start?: boolean | undefined;
+  max_files?: number | undefined;
+  include_thumbnails?: boolean | undefined;
+};
+type MetadataImportFilterSet = Partial<{
+  from: string;
+  to: string;
+  folder_id: string;
+  path: string;
+  title_search: string;
+  team: string;
+  meeting_type: string;
+}>;
+type MetadataImportRun = Partial<{
+  object: 'metadata_import_run';
+  id: string;
+  import_id: string;
+  mode: 'append' | 'refresh';
+  delete_missing: boolean;
+  status: 'pending' | 'processing' | 'completed' | 'failed' | 'cancelled';
+  progress: MetadataImportRunProgress;
+  error: string | null;
+  started_at: number | null;
+  completed_at: number | null;
+  created_at: number;
+  max_files: number | null;
+  include_thumbnails: boolean;
+}>;
+type MetadataImportRunProgress = Partial<{
+  pages_listed: number;
+  files_listed: number;
+  files_created: number;
+  files_updated: number;
+  files_skipped: number;
+  files_failed: number;
+  files_queued: number;
+  files_indexed: number;
+  files_removed: number;
+}>;
+type MetadataImportList = Partial<{
+  object: 'list';
+  data: Array<MetadataImport>;
+  total: number;
+  limit: number;
+  offset: number;
+}>;
+type MetadataImportDetail = Partial<{
+  object: 'metadata_import';
+  id: string;
+  collection_id: string;
+  connector_id: string;
+  name: string;
+  filters: Array<MetadataImportFilterSet>;
+  default_mode: 'append' | 'refresh';
+  delete_missing: boolean;
+  rate_limit: number | null;
+  created_at: number;
+  runs: Array<MetadataImportRun>;
+  total_runs: number;
+  limit: number;
+  offset: number;
+  max_files: number | null;
+  include_thumbnails: boolean;
+}>;
+
+const MetadataImportRunProgress: z.ZodType<MetadataImportRunProgress> = z
+  .object({
+    pages_listed: z.number().int(),
+    files_listed: z.number().int(),
+    files_created: z.number().int(),
+    files_updated: z.number().int(),
+    files_skipped: z.number().int(),
+    files_failed: z.number().int(),
+    files_queued: z.number().int(),
+    files_indexed: z.number().int(),
+    files_removed: z.number().int(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const MetadataImportRun: z.ZodType<MetadataImportRun> = z
+  .object({
+    object: z.literal('metadata_import_run'),
+    id: z.string().uuid(),
+    import_id: z.string().uuid(),
+    mode: z.enum(['append', 'refresh']),
+    delete_missing: z.boolean(),
+    status: z.enum([
+      'pending',
+      'processing',
+      'completed',
+      'failed',
+      'cancelled',
+    ]),
+    progress: MetadataImportRunProgress,
+    error: z.string().nullable(),
+    started_at: z.number().nullable(),
+    completed_at: z.number().nullable(),
+    created_at: z.number(),
+    max_files: z.number().int().nullable(),
+    include_thumbnails: z.boolean(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const MetadataImportFilterSet: z.ZodType<MetadataImportFilterSet> = z
+  .object({
+    from: z.string(),
+    to: z.string(),
+    folder_id: z.string(),
+    path: z.string(),
+    title_search: z.string(),
+    team: z.string(),
+    meeting_type: z.string(),
+  })
+  .partial()
+  .strict();
+const MetadataImport: z.ZodType<MetadataImport> = z
+  .object({
+    object: z.literal('metadata_import'),
+    id: z.string().uuid(),
+    collection_id: z.string().uuid(),
+    connector_id: z.string().uuid(),
+    name: z.string(),
+    filters: z.array(MetadataImportFilterSet),
+    default_mode: z.enum(['append', 'refresh']),
+    delete_missing: z.boolean(),
+    rate_limit: z.number().int().nullable(),
+    created_at: z.number(),
+    latest_run: MetadataImportRun.nullable(),
+    max_files: z.number().int().nullable(),
+    include_thumbnails: z.boolean(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const MetadataImportDetail: z.ZodType<MetadataImportDetail> = z
+  .object({
+    object: z.literal('metadata_import'),
+    id: z.string().uuid(),
+    collection_id: z.string().uuid(),
+    connector_id: z.string().uuid(),
+    name: z.string(),
+    filters: z.array(MetadataImportFilterSet),
+    default_mode: z.enum(['append', 'refresh']),
+    delete_missing: z.boolean(),
+    rate_limit: z.number().int().nullable(),
+    created_at: z.number(),
+    runs: z.array(MetadataImportRun),
+    total_runs: z.number().int(),
+    limit: z.number().int(),
+    offset: z.number().int(),
+    max_files: z.number().int().nullable(),
+    include_thumbnails: z.boolean(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const MetadataImportList: z.ZodType<MetadataImportList> = z
+  .object({
+    object: z.literal('list'),
+    data: z.array(MetadataImport),
+    total: z.number().int(),
+    limit: z.number().int(),
+    offset: z.number().int(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const CreateMetadataImportRequest: z.ZodType<CreateMetadataImportRequest> = z
+  .object({
+    name: z.string().min(1).max(255),
+    connector_id: z.string().uuid(),
+    filters: z.array(MetadataImportFilterSet).max(20).optional(),
+    default_mode: z.enum(['append', 'refresh']).optional(),
+    delete_missing: z.boolean().optional(),
+    rate_limit: z.number().int().gte(1).lte(50).optional(),
+    start: z.boolean().optional(),
+    max_files: z.number().int().gte(1).lte(1000000).optional(),
+    include_thumbnails: z.boolean().optional(),
+  })
+  .strict()
+  .passthrough();
+const MetadataImportDelete = z
+  .object({
+    object: z.literal('metadata_import'),
+    id: z.string().uuid(),
+    deleted: z.literal(true),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+const CreateMetadataImportRunRequest = z
+  .object({
+    mode: z.enum(['append', 'refresh']),
+    delete_missing: z.boolean(),
+    max_files: z.number().int().gte(1).lte(1000000),
+    include_thumbnails: z.boolean(),
+  })
+  .partial()
+  .strict()
+  .passthrough();
+
+export const schemas = {
+  MetadataImportRunProgress,
+  MetadataImportRun,
+  MetadataImportFilterSet,
+  MetadataImport,
+  MetadataImportDetail,
+  MetadataImportList,
+  CreateMetadataImportRequest,
+  MetadataImportDelete,
+  CreateMetadataImportRunRequest,
+};
+
+const endpoints = makeApi([
+  {
+    method: 'post',
+    path: '/collections/:collection_id/imports',
+    alias: 'createMetadataImport',
+    description: `Create a bulk metadata import for a metadata collection: a saved definition that lists a data connector&#x27;s source files and imports each one&#x27;s source metadata as a collection file, with no media download or processing. Runs consume no credits. By default the first run starts immediately (&#x60;start: false&#x60; saves the definition only). The response&#x27;s &#x60;latest_run&#x60; is the triggered run; it is null when &#x60;start&#x60; is false or when another import&#x27;s run currently holds the one-active-run-per-collection slot (the definition is saved and can be run once that finishes), and it is returned with status &#x60;failed&#x60; when the run could not be enqueued (trigger a new run to retry). Runs page the connector with the account&#x27;s default active API key and fail with a clear error when the account has none.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'body',
+        type: 'Body',
+        schema: CreateMetadataImportRequest,
+      },
+      {
+        name: 'collection_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: MetadataImport,
+    errors: [
+      {
+        status: 400,
+        description: `Invalid request — the collection is not a metadata collection, the connector does not exist, the connector type does not support metadata imports, or a filter key is not supported by the connector type`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 404,
+        description: `Collection not found`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 500,
+        description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'get',
+    path: '/collections/:collection_id/imports',
+    alias: 'listMetadataImports',
+    description: `List a collection&#x27;s metadata imports, newest first, each with its latest run inline.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'collection_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+      {
+        name: 'limit',
+        type: 'Query',
+        schema: z.number().int().gte(1).lte(100).optional(),
+      },
+      {
+        name: 'offset',
+        type: 'Query',
+        schema: z.number().int().gte(0).optional(),
+      },
+    ],
+    response: MetadataImportList,
+    errors: [
+      {
+        status: 404,
+        description: `Collection not found`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 500,
+        description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'get',
+    path: '/collections/:collection_id/imports/:import_id',
+    alias: 'getMetadataImport',
+    description: `Get a metadata import definition with one page of its run history (newest first).`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'collection_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+      {
+        name: 'import_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+      {
+        name: 'limit',
+        type: 'Query',
+        schema: z.number().int().gte(1).lte(100).optional(),
+      },
+      {
+        name: 'offset',
+        type: 'Query',
+        schema: z.number().int().gte(0).optional(),
+      },
+    ],
+    response: MetadataImportDetail,
+    errors: [
+      {
+        status: 404,
+        description: `Collection or import not found`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 500,
+        description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'delete',
+    path: '/collections/:collection_id/imports/:import_id',
+    alias: 'deleteMetadataImport',
+    description: `Delete an import definition and its run history. Any active run is cancelled first. Imported files and collection memberships are never deleted by this operation.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'collection_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+      {
+        name: 'import_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: MetadataImportDelete,
+    errors: [
+      {
+        status: 404,
+        description: `Collection or import not found`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 500,
+        description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'post',
+    path: '/collections/:collection_id/imports/:import_id/runs',
+    alias: 'createMetadataImportRun',
+    description: `Trigger a new run of a saved import. &#x60;mode&#x60; and &#x60;delete_missing&#x60; default to the definition&#x27;s saved values. Only one run may be active per collection at a time — concurrent runs would corrupt each other&#x27;s delete-missing bookkeeping — so triggering while any run in the collection is active returns a 409.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'body',
+        type: 'Body',
+        schema: CreateMetadataImportRunRequest.optional(),
+      },
+      {
+        name: 'collection_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+      {
+        name: 'import_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: MetadataImportRun,
+    errors: [
+      {
+        status: 404,
+        description: `Collection or import not found`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 409,
+        description: `A run of this import is already active, or another import in this collection has an active run`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 500,
+        description: `The run could not be enqueued and was marked failed — trigger a new run to retry`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+  {
+    method: 'post',
+    path: '/collections/:collection_id/imports/:import_id/runs/:run_id/cancel',
+    alias: 'cancelMetadataImportRun',
+    description: `Cancel an in-flight run. Files already imported by the run are kept. Cancelling an already-finished run is a no-op that returns the current state.`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'collection_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+      {
+        name: 'import_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+      {
+        name: 'run_id',
+        type: 'Path',
+        schema: z.string().uuid(),
+      },
+    ],
+    response: MetadataImportRun,
+    errors: [
+      {
+        status: 404,
+        description: `Collection, import, or run not found`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+      {
+        status: 500,
+        description: `An unexpected error occurred on the server`,
+        schema: z.object({ error: z.string() }).strict().passthrough(),
+      },
+    ],
+  },
+]);
+
+export const Metadata_ImportsApi = new Zodios(
+  'https://api.cloudglue.dev/v1',
+  endpoints
+);
+
+export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
+  return new Zodios(baseUrl, endpoints, options);
+}

--- a/generated/index.ts
+++ b/generated/index.ts
@@ -16,4 +16,5 @@ export { SegmentsApi } from './Segments';
 export { Face_MatchApi } from './Face_Match';
 export { Face_DetectionApi } from './Face_Detection';
 export { ShareApi } from './Share';
+export { Metadata_ImportsApi } from './Metadata_Imports';
 export { QueryApi } from './Query';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.24",
+  "version": "0.7.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.24",
+      "version": "0.7.25",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.24",
+  "version": "0.7.25",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/metadata-imports.api.ts
+++ b/src/api/metadata-imports.api.ts
@@ -1,0 +1,141 @@
+import { Metadata_ImportsApi } from '../../generated';
+import { schemas } from '../../generated/Metadata_Imports';
+import z from 'zod';
+
+/**
+ * Bulk metadata imports for metadata collections.
+ *
+ * A metadata import is a saved definition that lists a data connector's
+ * source files and imports each one's source metadata into a metadata
+ * collection as collection files — no media download or processing, and
+ * runs consume no credits.
+ */
+export class EnhancedMetadataImportsApi {
+  constructor(private readonly api: typeof Metadata_ImportsApi) {}
+
+  /**
+   * Create a bulk metadata import for a metadata collection.
+   *
+   * By default the first run starts immediately (`start: false` saves the
+   * definition only). The response's `latest_run` is the triggered run; it
+   * is null when `start` is false or when another import's run currently
+   * holds the one-active-run-per-collection slot, and has status `failed`
+   * when the run could not be enqueued. Runs page the connector with the
+   * account's default active API key and fail with a clear error when the
+   * account has none.
+   *
+   * Filters are listing passes — `from`/`to` date window (YYYY-MM-DD, UTC),
+   * `title_search`, `folder_id` (Google Drive only), `path` (Dropbox only —
+   * non-recursive, direct children), `team`/`meeting_type` (Grain only).
+   * Empty or omitted means one unfiltered pass; overlapping passes are
+   * deduplicated. `max_files` caps each run (a capped run never runs the
+   * delete-missing sweep); `rate_limit` overrides the per-connector safe
+   * listing rate and is clamped to a per-connector ceiling at run time.
+   *
+   * @param collectionId - The ID of the metadata collection
+   * @param params - The import definition (name + connector_id required)
+   * @returns The import definition with its latest run inline
+   */
+  async createMetadataImport(
+    collectionId: string,
+    params: z.infer<typeof schemas.CreateMetadataImportRequest>,
+  ) {
+    return this.api.createMetadataImport(params, {
+      params: { collection_id: collectionId },
+    });
+  }
+
+  /**
+   * List a collection's metadata imports, newest first, each with its
+   * latest run inline.
+   *
+   * @param collectionId - The ID of the metadata collection
+   * @param params - Pagination (limit default 50, max 100; offset)
+   */
+  async listMetadataImports(
+    collectionId: string,
+    params: { limit?: number; offset?: number } = {},
+  ) {
+    return this.api.listMetadataImports({
+      params: { collection_id: collectionId },
+      queries: params,
+    });
+  }
+
+  /**
+   * Get a metadata import definition with one page of its run history
+   * (newest first).
+   *
+   * @param collectionId - The ID of the metadata collection
+   * @param importId - The ID of the metadata import
+   * @param params - Run-history pagination (limit default 20; offset)
+   */
+  async getMetadataImport(
+    collectionId: string,
+    importId: string,
+    params: { limit?: number; offset?: number } = {},
+  ) {
+    return this.api.getMetadataImport({
+      params: { collection_id: collectionId, import_id: importId },
+      queries: params,
+    });
+  }
+
+  /**
+   * Delete a metadata import definition. Files the import brought into the
+   * collection are not removed.
+   *
+   * @param collectionId - The ID of the metadata collection
+   * @param importId - The ID of the metadata import
+   */
+  async deleteMetadataImport(collectionId: string, importId: string) {
+    return this.api.deleteMetadataImport(undefined, {
+      params: { collection_id: collectionId, import_id: importId },
+    });
+  }
+
+  /**
+   * Trigger a new run of a saved import. `mode` and `delete_missing`
+   * default to the definition's saved values; `max_files` and
+   * `include_thumbnails` can be overridden per run. Only one run may be
+   * active per collection at a time — triggering while any run in the
+   * collection is active fails with a 409.
+   *
+   * @param collectionId - The ID of the metadata collection
+   * @param importId - The ID of the metadata import
+   * @param params - Per-run overrides
+   * @returns The created run
+   */
+  async createMetadataImportRun(
+    collectionId: string,
+    importId: string,
+    params: z.infer<typeof schemas.CreateMetadataImportRunRequest> = {},
+  ) {
+    return this.api.createMetadataImportRun(params, {
+      params: { collection_id: collectionId, import_id: importId },
+    });
+  }
+
+  /**
+   * Cancel an active metadata import run. Files already imported by the run
+   * stay in the collection; the run is settled and marked cancelled.
+   *
+   * @param collectionId - The ID of the metadata collection
+   * @param importId - The ID of the metadata import
+   * @param runId - The ID of the run to cancel
+   * @returns The run with its post-cancel status
+   */
+  async cancelMetadataImportRun(
+    collectionId: string,
+    importId: string,
+    runId: string,
+  ) {
+    return this.api.cancelMetadataImportRun(undefined, {
+      params: {
+        collection_id: collectionId,
+        import_id: importId,
+        run_id: runId,
+      },
+    });
+  }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,6 +20,7 @@ import { createApiClient as createShareableApiClient } from '../generated/Share'
 import { createApiClient as createResponseApiClient } from '../generated/Response';
 import { createApiClient as createDataConnectorsApiClient } from '../generated/Data_Connectors';
 import { createApiClient as createDeepSearchApiClient } from '../generated/Deep_Search';
+import { createApiClient as createMetadataImportsApiClient } from '../generated/Metadata_Imports';
 import { ZodiosOptions } from '@zodios/core';
 import { EnhancedWebhooksApi } from './api/webhooks.api';
 import { EnhancedTagsApi } from './api/tags.api';
@@ -41,6 +42,7 @@ import { EnhancedShareableApi } from './api/shareable.api';
 import { EnhancedResponseApi } from './api/response.api';
 import { EnhancedDataConnectorsApi } from './api/data-connectors.api';
 import { EnhancedDeepSearchApi } from './api/deep-search.api';
+import { EnhancedMetadataImportsApi } from './api/metadata-imports.api';
 
 /**
  * Main Cloudglue client class that provides access to all API functionality
@@ -160,6 +162,12 @@ export class Cloudglue {
    */
   public readonly deepSearch: EnhancedDeepSearchApi;
 
+  /**
+   * Metadata Imports API for bulk-importing data-connector source metadata
+   * into metadata collections (definitions, runs, cancellation)
+   */
+  public readonly metadataImports: EnhancedMetadataImportsApi;
+
   constructor(config: CloudglueConfig = {}) {
     this.apiKey = config.apiKey || process.env.CLOUDGLUE_API_KEY || '';
     this.baseUrl = config.baseUrl || 'https://api.cloudglue.dev/v1';
@@ -223,6 +231,10 @@ export class Cloudglue {
       this.baseUrl,
       sharedConfig,
     );
+    const metadataImportsApi = createMetadataImportsApiClient(
+      this.baseUrl,
+      sharedConfig,
+    );
     // Configure base URL and axios config for all clients
     [
       filesApi,
@@ -244,6 +256,7 @@ export class Cloudglue {
       responseApi,
       dataConnectorsApi,
       deepSearchApi,
+      metadataImportsApi,
     ].forEach((client) => {
       Object.assign(client.axios.defaults, axiosConfig);
 
@@ -312,5 +325,6 @@ export class Cloudglue {
     this.responses = new EnhancedResponseApi(responseApi);
     this.dataConnectors = new EnhancedDataConnectorsApi(dataConnectorsApi);
     this.deepSearch = new EnhancedDeepSearchApi(deepSearchApi);
+    this.metadataImports = new EnhancedMetadataImportsApi(metadataImportsApi);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ import { schemas as shareableSchemas } from '../generated/Share';
 import { schemas as dataConnectorsSchemas } from '../generated/Data_Connectors';
 import { schemas as deepSearchSchemas } from '../generated/Deep_Search';
 import { schemas as querySchemas } from '../generated/Query';
+import { schemas as metadataImportsSchemas } from '../generated/Metadata_Imports';
 
 /**
  * Represents a video file in the Cloudglue system
@@ -668,3 +669,60 @@ export type QuerySchema = z.infer<typeof querySchemas.QuerySchema>;
  * Represents credit usage for a query run
  */
 export type QueryUsage = z.infer<typeof querySchemas.QueryUsage>;
+
+/**
+ * Represents a bulk metadata import definition, with its latest run inline
+ */
+export type MetadataImport = z.infer<
+  typeof metadataImportsSchemas.MetadataImport
+>;
+
+/**
+ * Represents a metadata import definition with one page of its run history
+ */
+export type MetadataImportDetail = z.infer<
+  typeof metadataImportsSchemas.MetadataImportDetail
+>;
+
+/**
+ * Represents a paginated list of a collection's metadata imports
+ */
+export type MetadataImportList = z.infer<
+  typeof metadataImportsSchemas.MetadataImportList
+>;
+
+/**
+ * Represents a single run of a metadata import
+ */
+export type MetadataImportRun = z.infer<
+  typeof metadataImportsSchemas.MetadataImportRun
+>;
+
+/**
+ * Represents progress counters for a metadata import run
+ */
+export type MetadataImportRunProgress = z.infer<
+  typeof metadataImportsSchemas.MetadataImportRunProgress
+>;
+
+/**
+ * Represents one listing pass of a metadata import (date window, title
+ * search, and connector-specific narrowing)
+ */
+export type MetadataImportFilterSet = z.infer<
+  typeof metadataImportsSchemas.MetadataImportFilterSet
+>;
+
+/**
+ * Parameters for creating a metadata import definition
+ */
+export type CreateMetadataImportParams = z.infer<
+  typeof metadataImportsSchemas.CreateMetadataImportRequest
+>;
+
+/**
+ * Per-run overrides when triggering a metadata import run
+ */
+export type CreateMetadataImportRunParams = z.infer<
+  typeof metadataImportsSchemas.CreateMetadataImportRunRequest
+>;


### PR DESCRIPTION
## Summary

Syncs the SDK to spec **v0.7.17** (cloudglue/cloudglue-api-spec#110) and bumps the package to **0.7.25**. One feature: **bulk metadata imports** — saved definitions that list a data connector's source files and import each one's source metadata into a metadata collection (no media download, no credits), with run history, modes, caps, and cancellation.

### Generated
- New `generated/Metadata_Imports.ts` (zodios client + zod schemas for the six operations over `/collections/:collection_id/imports`) and `Metadata_ImportsApi` export
- All new schemas live in the new file — `generated/common.ts` untouched, so no `| null` widening leakage to existing types
- Spec submodule → v0.7.17

### Wrapper (src/)
- New `client.metadataImports` (`EnhancedMetadataImportsApi`): `createMetadataImport` (full definition surface — `filters`, `default_mode`, `delete_missing`, `rate_limit`, `start`, `max_files`, `include_thumbnails`), `listMetadataImports`, `getMetadataImport` (pages run history via `limit`/`offset`), `deleteMetadataImport`, `createMetadataImportRun` (per-run overrides, 409 when a run is already active in the collection), `cancelMetadataImportRun`
- JSDoc carries the spec's semantics: append vs refresh, delete-missing sweep scope, capped runs never sweep, per-connector rate-limit clamping
- `src/types.ts` re-exports: `MetadataImport`, `MetadataImportDetail`, `MetadataImportList`, `MetadataImportRun`, `MetadataImportRunProgress`, `MetadataImportFilterSet`, `CreateMetadataImportParams`, `CreateMetadataImportRunParams`

Entirely additive — no existing wrapper methods or types change. Wrapper pagination keys match wire names (`limit`/`offset`), so nothing hits the verbatim-queries pitfall.

## Test plan

- [x] `npm run build` clean; `npm test` 107/107
- [x] Live battery against **production** — **11/11** (evidence in `~/Downloads/cloudglue-v0.7.17-sdk-test-results.md`, matching Python battery 11/11): throwaway metadata collection + google-drive import with `max_files: 3`; create(`start: false`) saves definition only; list/get; run trigger; concurrent trigger 409; capped run completes with `listed=3 queued=3 indexed=3 failed=0`; append rerun skips all 3; `get({limit: 1})` pages run history; cancel lands as `cancelled`; delete then get 404; collection deleted at cleanup — account left clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Entirely additive SDK surface with no changes to existing client methods or shared generated types.
> 
> **Overview**
> Adds **bulk metadata imports** to the JS SDK (spec v0.7.17): saved definitions that pull data-connector source metadata into metadata collections without media processing.
> 
> Introduces generated `Metadata_Imports` Zodios client and wires **`client.metadataImports`** with create/list/get/delete import definitions, trigger runs (with per-run overrides and 409 when another run is active in the collection), and cancel runs. Public types (`MetadataImport`, runs, filters, create params) are re-exported from `src/types.ts`. Package version bumps **0.7.24 → 0.7.25**; existing APIs and `generated/common.ts` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ce5129d4f811858a676b79fc0f7ad5f959bccf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->