### PR TITLE
docs: catch embedded docs up to spec v0.7.17 (query, metadata imports, metadata collections, iconik)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ npm run generate             # Regenerate clients
 **Layered SDK Pattern:**
 - `/generated/` - Auto-generated Zodios API clients from OpenAPI spec (do not edit manually)
 - `/src/api/` - Enhanced wrapper classes providing user-friendly interfaces over generated clients
-- `/src/client.ts` - Main `Cloudglue` class that orchestrates all 15 API clients
+- `/src/client.ts` - Main `Cloudglue` class that orchestrates all 20 API clients
 - `/src/index.ts` - Public exports
 
 **Code Generation Pipeline:**
@@ -50,12 +50,17 @@ npm run generate             # Regenerate clients
 ## API Surface
 
 The `Cloudglue` client exposes these API namespaces:
-- `files` - Upload, list, delete video files; manage segmentation
-- `collections` - Group videos for chat/search
+- `files` - Upload, list, delete video/audio/image files; sync from URL; refresh source metadata; manage segmentation
+- `collections` - Group videos for chat/search (types: media-descriptions, rich-transcripts, entities, face-analysis, metadata)
 - `chat` - LLM chat completions over video collections (model: nimbus-001)
+- `responses` - OpenAI-compatible Responses API (streaming, background jobs, tools)
 - `describe` - Rich video descriptions (visual, speech, text, audio modalities)
 - `extract` - Structured data extraction from videos
+- `query` - SQL / natural-language queries over extracted collection data
 - `search` - Semantic search across collections
+- `deepSearch` - Agentic retrieval with LLM summarization
+- `dataConnectors` - Browse & sync connected data sources (S3, GCS, Dropbox, Google Drive, Zoom, Gong, Recall, Grain, Iconik)
+- `metadataImports` - Bulk-import connector source metadata into metadata collections
 - `segments`, `segmentations` - Video segment management
 - `frames` - Frame extraction
 - `faceDetection`, `faceMatch` - Face recognition features

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -8,8 +8,9 @@ Collections group videos together for batch processing and querying (chat, searc
 |------|-------------|----------|
 | `media-descriptions` | Full multimodal (speech + visual + scene text + audio) | Chat, Search, Responses, Deep Search |
 | `rich-transcripts` | Speech-focused with visual context | Chat, Search, Deep Search |
-| `entities` | Structured extracted data | Responses API (entity-backed with nimbus-002-preview) |
+| `entities` | Structured extracted data | Query API (SQL), Search & Deep Search (file scope, `doc_lexical`), Responses API (entity-backed with nimbus-002-preview) |
 | `face-analysis` | Face detection data | Face-specific queries |
+| `metadata` | Connector source metadata + user metadata indexed into file-level search docs — no media download or processing, free to index | Search & Deep Search (file scope, `doc_lexical`), metadata-mode extraction |
 
 ## Create a Collection
 
@@ -21,8 +22,20 @@ const collection = await client.collections.createCollection({
   // default_segmentation_config: { strategy: 'shot-detector' },
   // describe_config: { enable_speech: true, enable_visual_scene_description: true },
   // default_thumbnails_config: { ... },
+  // For 'entities' collections:
+  // extract_config: { prompt, schema, enable_video_level_entities,
+  //                   enable_segment_level_entities, enable_transcript_mode,
+  //                   enable_metadata_mode },
 });
 ```
+
+Only provide the config that matches the `collection_type` — other configs are ignored.
+
+## Metadata Collections
+
+`collection_type: 'metadata'` indexes connector source metadata and user metadata into file-level search documents **without downloading or processing the media**. Indexing is free. Supported sources: google-drive, dropbox, zoom, gong, recall, grain, and iconik URLs. No processing configs are accepted.
+
+Populate one via `addMedia` with connector-synced files, or in bulk with the [Metadata Imports API](./metadata-imports.md) (`client.metadataImports`). Query with search/deep search at `file` scope (the `doc_lexical` modality matches the metadata docs), or run metadata-mode extraction over the files (see [Extract](./extract.md)). Refresh a single file's source metadata — and re-index its documents — with `client.files.syncSourceMetadata(fileId)`.
 
 ## Add Videos
 
@@ -91,6 +104,7 @@ const descriptions = await client.collections.getMediaDescriptions(collectionId,
   include_thumbnails: true,
   include_word_timestamps: true,
   include_chapters: true,            // requires narrative segmentation
+  include_metadata: true,            // include file's `metadata` + `source_metadata` on `file`
 });
 
 // Get transcripts (for 'rich-transcripts' type)
@@ -101,6 +115,7 @@ const transcripts = await client.collections.getTranscripts(collectionId, fileId
 });
 
 // List all entities/descriptions/transcripts across a collection
+// (description/transcript listings also accept include_metadata)
 const allEntities = await client.collections.listEntities(collectionId, { limit: 50 });
 const allDescriptions = await client.collections.listMediaDescriptions(collectionId, { limit: 50 });
 const allTranscripts = await client.collections.listRichTranscripts(collectionId, { limit: 50 });

--- a/docs/data-connectors.md
+++ b/docs/data-connectors.md
@@ -4,7 +4,7 @@ Browse files available in connected external data sources and sync them into Clo
 
 ## Supported Connectors
 
-S3, Google Cloud Storage (GCS), Dropbox, Google Drive, Zoom, Gong, Recall, Grain
+S3, Google Cloud Storage (GCS), Dropbox, Google Drive, Zoom, Gong, Recall, Grain, Iconik
 
 ## List Connectors
 
@@ -22,17 +22,19 @@ const files = await client.dataConnectors.listFiles(connectorId, {
   from: '2025-01-01',           // YYYY-MM-DD format
   to: '2025-06-01',
   // Provider-specific filters:
-  folder_id: 'folder_123',    // Google Drive, Dropbox
-  path: '/recordings/',        // path-based sources
-  bucket: 'my-bucket',        // S3, GCS
+  folder_id: 'folder_123',    // Google Drive
+  path: '/recordings/',        // Dropbox (folder path, default root)
+  bucket: 'my-bucket',        // S3, GCS (required for these)
   prefix: 'videos/',          // S3, GCS
-  title_search: 'video-title', // Grain
+  title_search: 'video-title', // Grain, Zoom, Google Drive, Dropbox, Gong, Iconik
   team: 'team-name',           // Grain
   meeting_type: 'type-123'     // Grain
 });
 ```
 
-Each returned file has a `uri` (null for folders). These URIs are the canonical input for syncing — pass them verbatim to `syncFile()`/`syncUrl()`, or to general ingestion methods like `client.collections.addMediaByUrl()` or `client.describe.createDescribe()`.
+The `from`/`to` date filters are supported by Grain, Zoom, Recall, Google Drive, Dropbox, Gong, and Iconik (Zoom and Gong default to a 6-month lookback when omitted); they're ignored for S3/GCS. Filters a connector can't honor are silently ignored, and a filtered page may contain fewer than `limit` items (even zero) while `has_more` is still true — keep paginating until `next_page_token` is null.
+
+Each returned file has a `uri` (null for folders), per-file provider `metadata` (participants, hosts, durations, AI summaries), and an ephemeral `thumbnail_url` where the provider offers one. These URIs are the canonical input for syncing — pass them verbatim to `syncFile()`/`syncUrl()`, or to general ingestion methods like `client.collections.addMediaByUrl()` or `client.describe.createDescribe()`.
 
 ## Sync a File
 
@@ -61,6 +63,7 @@ Each connector type accepts URIs in the form emitted by `listFiles()`:
 | `grain` | `grain://recording/<recordingId>` |
 | `gong` | `gong://call/<callId>` |
 | `recall` | `recall://recording/<recordingId>` |
+| `iconik` | `iconik://asset/<assetId>` |
 
 `dropbox://` path parsing is tolerant: any leading-slash count and %-encoding spellings of the same path resolve — and dedupe — to the same file.
 
@@ -83,7 +86,7 @@ URLs that cannot map to any connector type — generic http(s) video URLs, YouTu
 
 ## Get Source Metadata
 
-Fetch metadata for a connector URI from the upstream source without creating a Cloudglue file. Currently supported for Grain; other connector types return 501.
+Fetch metadata for a connector URI from the upstream source without creating a Cloudglue file. Supported for Grain, Zoom, Recall, Google Drive, Dropbox, Gong, and Iconik; S3/GCS return 501 (plain object stores have no richer metadata).
 
 ```typescript
 const metadata = await client.dataConnectors.getSourceMetadata(
@@ -91,3 +94,5 @@ const metadata = await client.dataConnectors.getSourceMetadata(
   'grain://recording/<recordingId>',
 );
 ```
+
+Synced connector files carry the same provider metadata on their `source_metadata` field. To re-fetch it live for an existing file (and re-index any metadata collections it belongs to), use `client.files.syncSourceMetadata(fileId)` — see [Files](./files.md). To index a connector's metadata at scale without downloading media, see [Metadata Imports](./metadata-imports.md).

--- a/docs/deep-search.md
+++ b/docs/deep-search.md
@@ -25,7 +25,11 @@ const result = await client.deepSearch.createDeepSearch({
 Same as the Responses API:
 
 ```typescript
-// Collections
+// Collections — may be of type media-descriptions, rich-transcripts,
+// metadata, or entities. With an explicit scope, every collection must be
+// searchable at that scope (metadata and file-level entities collections
+// require 'file'; segment-level entities collections require 'segment');
+// omit scope to let the planner pick per collection.
 { source: 'collections', collections: ['col_id'], filter: { /* optional */ } }
 
 // Individual files

--- a/docs/describe.md
+++ b/docs/describe.md
@@ -25,9 +25,12 @@ const job = await client.describe.createDescribe(
     },
     // thumbnails_config: { ... },
     // segmentation_id: 'existing_seg_id',  // use existing segmentation
+    // participants: [{ name: 'Ada Lovelace' }, { name: 'Alan Turing' }],
   }
 );
 ```
+
+**Participants:** pass `participants` to constrain speaker naming — transcript speaker labels will only use one of the given names (or a generic "Speaker N"), never an invented name. Intended for uploaded files, which carry no participant metadata; for data-connector files (e.g. Grain) participants are populated automatically and need not be supplied.
 
 ## Wait for Completion
 
@@ -51,6 +54,7 @@ const describe = await client.describe.getDescribe(jobId, {
   include_word_timestamps: true,
   include_chapters: true,            // requires narrative segmentation on the file
   include_shots: true,               // requires shot_detector segmentation on the file
+  include_metadata: true,            // include file's `metadata` + `source_metadata` on `file`
 });
 ```
 
@@ -63,6 +67,7 @@ const describes = await client.describe.listDescribes({
   include_data: true,
   response_format: 'json',
   modalities: ['speech'],
+  include_metadata: true,   // include each file's `metadata` + `source_metadata`
   limit: 10,
 });
 

--- a/docs/extract.md
+++ b/docs/extract.md
@@ -22,6 +22,7 @@ const job = await client.extract.createExtract(
     enable_segment_level_entities: true,   // per-segment extraction (default behavior)
     enable_video_level_entities: false,    // set true for whole-video extraction instead
     enable_transcript_mode: false,         // set true for transcript-only extraction
+    enable_metadata_mode: false,           // set true to extract from the file's metadata document
     // segmentation_config, segmentation_id, thumbnails_config also available
   }
 );
@@ -62,5 +63,10 @@ await client.extract.deleteExtract(jobId);
 
 - **Segment-level** (`enable_segment_level_entities: true`): Extracts entities per video segment. Each segment produces its own structured output. This is the default.
 - **Video-level** (`enable_video_level_entities: true`): Extracts entities for the entire video as a single output.
+- **Metadata mode** (`enable_metadata_mode: true`): Extracts entities from the file's **metadata document** (filename, file details, user metadata, connector source metadata) instead of the media content. File-level entities only, flat 1 credit per file, and works on metadata-only files (e.g. files in a `metadata` collection) — the media itself is never processed.
 
-These modes are mutually exclusive — set one to `true` and the other to `false`.
+Segment-level and video-level are mutually exclusive — set one to `true` and the other to `false`.
+
+## Query Extracted Data
+
+Once files have completed extractions, run SQL or natural-language queries over the results with the [Query API](./query.md) (`client.query`).

--- a/docs/files.md
+++ b/docs/files.md
@@ -84,6 +84,14 @@ await client.files.updateFile(fileId, {
 await client.files.deleteFile(fileId);
 ```
 
+## Refresh Source Metadata
+
+For connector-backed files (google-drive, dropbox, zoom, gong, recall, grain, iconik), re-fetch `source_metadata` live from the data connector and update the stored value. If the file belongs to any metadata collections, their search documents are re-indexed with the refreshed metadata. Works for both metadata-only and fully ingested connector files; free — no media is downloaded or processed.
+
+```typescript
+const refreshed = await client.files.syncSourceMetadata(fileId);
+```
+
 ## File Segments & Segmentations
 
 ```typescript

--- a/docs/metadata-imports.md
+++ b/docs/metadata-imports.md
@@ -1,0 +1,76 @@
+# Metadata Imports API
+
+Bulk-import a data connector's source metadata into a metadata collection. A metadata import is a saved definition that lists the connector's source files and imports each one's source metadata as collection files — no media is downloaded or processed, and runs consume no credits.
+
+Metadata imports only apply to collections of type `metadata` (see [Collections](./collections.md)). Runs page the connector with the account's default active API key and fail with a clear error when the account has none.
+
+## Create an Import
+
+By default the first run starts immediately (`start: false` saves the definition only):
+
+```typescript
+const imp = await client.metadataImports.createMetadataImport(collectionId, {
+  name: 'All Grain recordings',
+  connector_id: 'connector_uuid',
+  // Optional:
+  filters: [{ from: '2026-01-01', to: '2026-06-30' }],  // up to 20 listing passes
+  default_mode: 'append',        // 'append' | 'refresh'
+  delete_missing: false,         // remove collection files no longer in the source
+  rate_limit: 10,                // listing requests/sec (1-50, clamped per connector)
+  start: true,                   // default: true
+  max_files: 10000,              // cap per run (a capped run skips the delete-missing sweep)
+  include_thumbnails: false,
+});
+
+console.log(imp.latest_run);     // the triggered run (null if start: false or slot busy)
+```
+
+### Filters
+
+Each entry in `filters` is one listing pass over the connector; overlapping passes are deduplicated. Empty or omitted means a single unfiltered pass. Per-connector fields:
+
+- `from` / `to` — date window (YYYY-MM-DD, UTC)
+- `title_search` — title filter
+- `folder_id` — Google Drive only
+- `path` — Dropbox only (non-recursive, direct children)
+- `team` / `meeting_type` — Grain only
+
+## List, Get, Delete
+
+```typescript
+// List a collection's imports, newest first, each with its latest run inline
+const imports = await client.metadataImports.listMetadataImports(collectionId, { limit: 50 });
+
+// Get a definition with one page of its run history (newest first)
+const detail = await client.metadataImports.getMetadataImport(collectionId, importId, {
+  limit: 20,
+  offset: 0,
+});
+
+// Delete the definition (files it imported stay in the collection)
+await client.metadataImports.deleteMetadataImport(collectionId, importId);
+```
+
+## Trigger & Cancel Runs
+
+Only one run may be active per collection at a time — triggering while any run in the collection is active fails with 409.
+
+```typescript
+// mode/delete_missing default to the definition's saved values
+const run = await client.metadataImports.createMetadataImportRun(collectionId, importId, {
+  mode: 'refresh',               // optional per-run override
+  max_files: 500,                // optional per-run override
+});
+
+// Cancel an active run (files already imported stay in the collection)
+await client.metadataImports.cancelMetadataImportRun(collectionId, importId, run.id);
+```
+
+## Modes
+
+| Mode | Behavior |
+|------|----------|
+| `append` | Only files not already in the collection are imported |
+| `refresh` | Existing files' source metadata is re-fetched and re-indexed too |
+
+To refresh a single file's source metadata instead of a whole run, use `client.files.syncSourceMetadata(fileId)` — see [Files](./files.md).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,13 +8,15 @@ Cloudglue turns video into LLM-ready data. This SDK (`@cloudglue/cloudglue-js`) 
 Files (upload video/audio/image, media URL, data connector URI)
   → Processing (describe, extract, face detection)
     → Collections (group processed files)
-      → Querying (chat, search, deep search, responses API)
+      → Querying (chat, search, deep search, responses API, SQL query)
 ```
 
 1. **Upload** a video, audio, or image file, provide a URL, or provide a data connector URI
 2. **Process** it with describe (multimodal descriptions) or extract (structured data)
 3. **Organize** files into collections
-4. **Query** collections via chat, search, deep search, or the Responses API
+4. **Query** collections via chat, search, deep search, the Responses API, or SQL/natural-language queries over extracted data
+
+Collections of type `metadata` skip step 2: they index connector source metadata + user metadata into searchable file-level documents without downloading or processing the media — see [Collections](./collections.md) and [Metadata Imports](./metadata-imports.md).
 
 ## SDK Architecture
 
@@ -36,10 +38,11 @@ The SDK also exports standalone URL helpers (`classifyVideoUrl`, `normalizeVideo
 
 | Namespace | Purpose | Key Methods |
 |-----------|---------|-------------|
-| `client.files` | Upload & manage video, audio & image files | `uploadFile`, `syncFromUrl`, `listFiles`, `getFile`, `deleteFile`, `waitForReady` |
+| `client.files` | Upload & manage video, audio & image files | `uploadFile`, `syncFromUrl`, `syncSourceMetadata`, `listFiles`, `getFile`, `deleteFile`, `waitForReady` |
 | `client.collections` | Organize videos into groups | `createCollection`, `addMedia`, `listVideos`, `waitForReady` |
 | `client.describe` | Multimodal video descriptions | `createDescribe`, `getDescribe`, `waitForReady` |
 | `client.extract` | Structured data extraction | `createExtract`, `getExtract`, `waitForReady` |
+| `client.query` | SQL / natural-language queries over extracted data | `runQuery`, `getQuerySchema`, `listQueries`, `getQuery`, `waitForReady` |
 | `client.chat` | Chat over video collections | `createCompletion`, `getCompletion` |
 | `client.responses` | OpenAI-compatible Responses API | `createResponse`, `createStreamingResponse`, `waitForReady` |
 | `client.search` | Semantic search | `searchContent` |
@@ -50,6 +53,7 @@ The SDK also exports standalone URL helpers (`classifyVideoUrl`, `normalizeVideo
 | `client.faceDetection` | Detect faces in video | `createFaceDetection`, `waitForReady` |
 | `client.faceMatch` | Match faces across videos | `createFaceMatch`, `waitForReady` |
 | `client.dataConnectors` | Browse & sync connected data sources | `list`, `listFiles`, `syncFile`, `syncUrl`, `getSourceMetadata` |
+| `client.metadataImports` | Bulk-import connector source metadata into metadata collections | `createMetadataImport`, `listMetadataImports`, `createMetadataImportRun` |
 | `client.webhooks` | Event notifications | CRUD operations |
 | `client.tags` | Video tagging | CRUD operations |
 | `client.shareable` | Public sharing links | CRUD operations |

--- a/docs/query.md
+++ b/docs/query.md
@@ -1,0 +1,105 @@
+# Query API
+
+Run read-only SQL — or natural-language questions compiled to SQL — over the structured data extracted from your collections. Queries execute against three virtual tables built from each file's most recent completed extraction:
+
+| Table | Contents |
+|-------|----------|
+| `files` | One row per collection file (filename, uri, duration, metadata, ...) |
+| `entities` | File-level extracted entities |
+| `segment_entities` | Segment-level extracted entities with timestamps |
+
+The `entities`/`segment_entities` tables are populated from collection extractions, so the Query API is most useful over `entities` collections; for collections without extractions only the `files` table has data. Face-analysis collections cannot be queried (rejected with 400). Queries are stored, so completed runs can be re-fetched later.
+
+## Discover the Schema
+
+Introspect the queryable tables and per-collection extracted fields before writing SQL — column names, entity field names, types, and levels, plus each collection's verbatim extract schema and prompt:
+
+```typescript
+const schema = await client.query.getQuerySchema(['col_id_1', 'col_id_2']); // 1-20 collections
+```
+
+## Run a SQL Query
+
+```typescript
+const result = await client.query.runQuery({
+  collections: ['col_id'],           // 1-20 collection IDs
+  sql: `SELECT e.name, COUNT(*) AS mentions
+        FROM entities e
+        GROUP BY e.name
+        ORDER BY mentions DESC
+        LIMIT 10`,
+  max_rows: 1000,                    // optional, 1-10000
+});
+
+console.log(result.columns, result.rows);
+```
+
+Each SQL query costs 2 credits. Only a single `SELECT` statement is accepted — multiple statements, non-SELECT statements, and unparseable SQL are rejected with 400.
+
+## Natural-Language Queries
+
+Provide `query` instead of `sql` and Cloudglue compiles the question to SQL against the same virtual schema (4 credits). The compiled statement is returned in the result's `sql` field:
+
+```typescript
+const result = await client.query.runQuery({
+  collections: ['col_id'],
+  query: 'Which products were mentioned most often, with average price?',
+});
+
+console.log(result.sql);   // the compiled SQL
+console.log(result.rows);
+```
+
+Provide exactly one of `sql` or `query`.
+
+## Dry Run
+
+Validate SQL (or compile a natural-language question) without executing:
+
+```typescript
+const check = await client.query.runQuery({
+  collections: ['col_id'],
+  sql: 'SELECT ...',
+  dry_run: true,
+});
+```
+
+## Background Exports
+
+For large result sets, run the query in the background and export to a file retrievable via `download_url`:
+
+```typescript
+const run = await client.query.runQuery({
+  collections: ['col_id'],
+  sql: 'SELECT * FROM segment_entities',
+  background: true,
+  format: 'csv',                     // 'json' | 'csv' | 'jsonl'
+});
+
+const done = await client.query.waitForReady(run.id);
+console.log(done.download_url);
+
+// Cancel an in-progress export (reserved credits are refunded)
+await client.query.cancelQueryExport(run.id);
+```
+
+## List & Get Query Runs
+
+```typescript
+// List runs (list items omit the columns/rows payloads)
+const history = await client.query.listQueries({ limit: 10, status: 'completed' });
+
+// Fetch a stored run with its full result. Results larger than the inline
+// storage cap are replayed truncated (truncated: true).
+const run = await client.query.getQuery(queryId);
+```
+
+## Errors
+
+| Status | Meaning |
+|--------|---------|
+| 400 | Invalid parameters or rejected SQL (multiple statements, non-SELECT, unparseable, or a face-analysis collection in scope) |
+| 402 | Insufficient credit balance |
+| 404 | One or more collections not found |
+| 408 | Query exceeded the execution time limit |
+| 409 | The selected collections exceed the maximum queryable dataset size |

--- a/docs/search.md
+++ b/docs/search.md
@@ -9,8 +9,8 @@ import { FilterOperator } from '@cloudglue/cloudglue-js';
 
 const results = await client.search.searchContent({
   query: 'product demo pricing discussion',
-  collection_ids: ['col_id_1'],
-  scope: 'segment',      // 'segment' (timestamp-level) or 'file' (whole video)
+  collections: ['col_id_1'],
+  scope: 'segment',      // 'segment' (timestamp-level), 'file' (whole video), or 'face'
   limit: 10,
   filter: {
     metadata: [{
@@ -33,6 +33,22 @@ const results = await client.search.searchContent({
 |-------|---------|----------|
 | `segment` | Timestamp-level matches within videos | Finding specific moments |
 | `file` | Whole-video relevance scores | Finding which videos are relevant |
+| `face` | Face matches (use with `source_image`) | Finding a person across videos |
+
+## Search Modalities
+
+Pass `search_modalities` (up to 5) to control what is searched; multiple modalities run as a hybrid search that combines results from each:
+
+| Modality | Matches against |
+|----------|-----------------|
+| `general_content` | Baseline semantic match on visual/spoken content similarity to the query |
+| `speech_lexical` | Keyword/exact match on speech transcripts |
+| `ocr_lexical` | Keyword/exact match on on-screen text |
+| `tag_semantic` | Semantic similarity on tag values |
+| `tag_lexical` | Keyword/exact match on tag values |
+| `doc_lexical` | Keyword/exact match on file-level documents — generated summaries, metadata-collection docs, and entity-collection docs. `scope: 'file'` only. |
+
+`doc_lexical` is how you search `metadata` and `entities` collections (see [Collections](./collections.md)).
 
 ## Filter Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudglue/cloudglue-js",
-      "version": "0.7.25",
+      "version": "0.7.26",
       "license": "Apache-2.0",
       "dependencies": {
         "@zodios/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudglue/cloudglue-js",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "description": "Cloudglue API client for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
## Summary

- The embedded `docs/` stopped tracking the API surface after v0.7.16: the **Query API** (v0.7.15), **metadata collections / iconik / source-metadata search** (v0.7.11), **`enable_metadata_mode`** (v0.7.12), **`participants`** (v0.7.7), and **metadata imports** (v0.7.17) all shipped with no doc coverage. This adds two new pages (`docs/query.md`, `docs/metadata-imports.md`) and updates 8 existing pages plus `CLAUDE.md` (namespace list was missing 5 clients and said "15 API clients"; it's 20).
- Fixes a doc bug: `search.md` showed `collection_ids:` as the search request param — the real param is `collections` (per `SearchRequest` in `generated/Search.ts`).
- Corrects stale claims: `getSourceMetadata` was documented as "Grain only" (now Grain, Zoom, Recall, Google Drive, Dropbox, Gong, Iconik; S3/GCS 501), and the collections table now reflects that `entities` collections are searchable at file scope via `doc_lexical`.
- Bumps the package to **0.7.26** (docs-only release so the updated embedded docs ship in `node_modules`). The bump is intentionally untagged — **after merge, tag the merge commit `v0.7.26`** (`git tag v0.7.26 && git push --follow-tags` from `main`) to trigger the release workflow, per RELEASING.md.

## Test plan

- [x] Every new parameter name, request/response field, credit cost, and error status verified against the generated Zod schemas (`generated/Query.ts`, `generated/Metadata_Imports.ts`, `generated/Search.ts`, `generated/Collections.ts`, `generated/Extract.ts`) and the v0.7.17 OpenAPI spec — not just commit messages
- [x] Wrapper method names/signatures in examples checked against `src/api/*.api.ts` (`query.api.ts`, `metadata-imports.api.ts`, `files.api.ts` `syncSourceMetadata`, `data-connectors.api.ts`)
- [x] Markdown table column-consistency lint over all edited files (clean; the two flags in `data-connectors.md` are pre-existing escaped pipes)
- [x] `docs/` is in the npm `files` array, so the new pages ship with the package
- [x] `npm version patch --no-git-tag-version` kept `package.json` and `package-lock.json` in sync (0.7.26)